### PR TITLE
feat!: use js-car blockstore interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export interface Block {
 }
 
 export interface Blockstore {
-  get: (cid: CID, options?: { signal?: AbortSignal }) => Promise<Uint8Array>
+  get: (cid: CID, options?: { signal?: AbortSignal }) => Promise<Block | undefined>
 }
 
 export interface Network {

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export declare class Dagula {
   /**
    * Get a single block.
    */
-  getBlock (cid: CID|string, options?: AbortOptions): Promise<Uint8Array>
+  getBlock (cid: CID|string, options?: AbortOptions): Promise<Block>
   /**
    * Get UnixFS files and directories.
    */


### PR DESCRIPTION
BREAKING CHANGE: The blockstore interface used by this library has been updated. If passing a blockstore to the constructor it should return `undefined` if the block is not present in the blockstore. If it is present, it should return a `{ bytes: Uint8Array, cid: CID }` object (a "Block"). Secondly the `getBlock` method now returns a `Block` instead of a `Uint8Array`.

resolves https://github.com/web3-storage/dagula/issues/3