### PR TITLE
feat!: support for multiple hash types

### DIFF
--- a/bitswap-fetcher.js
+++ b/bitswap-fetcher.js
@@ -8,10 +8,7 @@ import { Entry, Message, BlockPresenceType } from './message.js'
 import * as Prefix from './prefix.js'
 import { Hashers } from './defaults.js'
 
-/**
- * @typedef {import('./index').MultihashHashers} MultihashHashers
- * @typedef {import('./index').Block} Block
- */
+/** @typedef {import('./index').Block} Block */
 
 const MAX_OUTSTANDING_WANTS = 256
 const SEND_WANTLIST_DELAY = 5
@@ -26,12 +23,12 @@ export class BitswapFetcher {
   #wantlist = []
   /** @type {number} */
   #outstandingWants = 0
-  /** @type {Hashers} */
+  /** @type {import('./index').MultihashHashers} */
   #hashers
 
   /**
    * @param {() => Promise<import('@libp2p/interface-connection').Stream>} newStream
-   * @param {{ hashers?: MultihashHashers }} [options]
+   * @param {{ hashers?: import('./index').MultihashHashers }} [options]
    */
   constructor (newStream, options = {}) {
     this.#newStream = newStream
@@ -95,7 +92,7 @@ export class BitswapFetcher {
       throw options.signal.reason || abortError()
     }
 
-    // Ensure we can hash the data when we receive the block
+    // ensure we can hash the data when we receive the block
     if (!this.#hashers[cid.multihash.code]) {
       throw new Error(`missing hasher: ${cid.multihash.code} for wanted block: ${cid}`)
     }
@@ -143,7 +140,7 @@ export class BitswapFetcher {
               const hasher = this.#hashers[prefix.multihash.code]
               if (!hasher) {
                 // hasher presence for a wanted block has been checked before
-                // request so this must be unwanted
+                // request so this must have been sent in error
                 log('missing hasher %s', prefix.multihash.code)
                 continue
               }

--- a/bitswap-fetcher.js
+++ b/bitswap-fetcher.js
@@ -1,7 +1,6 @@
 import defer from 'p-defer'
 import { pipe } from 'it-pipe'
 import * as lp from 'it-length-prefixed'
-import { sha256 } from 'multiformats/hashes/sha2'
 import { base58btc } from 'multiformats/bases/base58'
 import debug from 'debug'
 import { Entry, Message, BlockPresenceType } from './message.js'

--- a/defaults.js
+++ b/defaults.js
@@ -1,0 +1,18 @@
+import * as raw from 'multiformats/codecs/raw'
+import * as dagPb from '@ipld/dag-pb'
+import * as dagCbor from '@ipld/dag-cbor'
+import * as dagJson from '@ipld/dag-json'
+import { sha256 } from 'multiformats/hashes/sha2'
+
+/** @type {import('./index').BlockDecoders} */
+export const Decoders = {
+  [raw.code]: raw,
+  [dagPb.code]: dagPb,
+  [dagCbor.code]: dagCbor,
+  [dagJson.code]: dagJson
+}
+
+/** @type {import('./index').MultihashHashers} */
+export const Hashers = {
+  [sha256.code]: sha256
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import type { BlockDecoder } from 'multiformats/codecs/interface'
+import type { MultihashHasher } from 'multiformats/hashes/interface'
 import type { CID } from 'multiformats'
 import type { UnixFSEntry } from 'ipfs-unixfs-exporter'
 import type { Multiaddr } from '@multiformats/multiaddr'
@@ -9,6 +10,10 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 
 export interface BlockDecoders {
   [code: number]: BlockDecoder<any, any>
+}
+
+export interface MultihashHashers {
+  [code: number]: MultihashHasher<any>
 }
 
 export interface Block {
@@ -41,11 +46,11 @@ export interface IDagula {
   /**
    * Emit nodes for all path segements and get UnixFS files and directories
    */
-  walkUnixfsPath (path: CID|string, options?: AbortOptions): Promise<UnixFSEntry>
+  walkUnixfsPath (path: CID|string, options?: AbortOptions): AsyncIterableIterator<UnixFSEntry>
 }
 
 export declare class Dagula implements IDagula {
-  constructor (blockstore: Blockstore, options?: { decoders?: BlockDecoders })
+  constructor (blockstore: Blockstore, options?: { decoders?: BlockDecoders, hashers?: MultihashHashers })
   /**
    * Get a complete DAG.
    */
@@ -61,9 +66,5 @@ export declare class Dagula implements IDagula {
   /**
    * Emit nodes for all path segements and get UnixFS files and directories
    */
-  walkUnixfsPath (path: CID|string, options?: AbortOptions): Promise<UnixFSEntry>
-  /**
-   * Create a new Dagula instance from the passed libp2p Network interface.
-   */
-  static fromNetwork (network: Network, options?: { decoders?: BlockDecoders, peer?: Multiaddr|string }): Promise<Dagula>
+  walkUnixfsPath (path: CID|string, options?: AbortOptions): AsyncIterableIterator<UnixFSEntry>
 }

--- a/message.js
+++ b/message.js
@@ -1,4 +1,5 @@
 import { CID } from 'multiformats/cid'
+import * as Prefix from './prefix.js'
 import * as gen from './gen/message.js'
 
 const MAX_PRIORITY = Math.pow(2, 31) - 1
@@ -129,12 +130,7 @@ export class Block {
    */
   constructor (prefixOrCid, data) {
     if (prefixOrCid instanceof CID) {
-      prefixOrCid = new Uint8Array([
-        prefixOrCid.version,
-        prefixOrCid.code,
-        prefixOrCid.multihash.bytes[0],
-        prefixOrCid.multihash.bytes[1]
-      ])
+      prefixOrCid = Prefix.encode(prefixOrCid)
     }
 
     this.prefix = prefixOrCid

--- a/p2p.d.ts
+++ b/p2p.d.ts
@@ -1,6 +1,13 @@
-import { Libp2p } from 'libp2p'
+import type { Libp2p } from 'libp2p'
+import type { Multiaddr } from '@multiformats/multiaddr'
+import type { Network, BlockDecoders, IDagula, MultihashHashers } from './index'
 
 /**
  * Create and start a default p2p networking stack (libp2p) with generated peer ID.
  */
 export declare function getLibp2p (): Promise<Libp2p>
+
+/**
+ * Create a new Dagula instance from the passed libp2p Network interface.
+ */
+export declare function fromNetwork (network: Network, options?: { decoders?: BlockDecoders, hashers?: MultihashHashers, peer?: Multiaddr|string }): Promise<IDagula>

--- a/p2p.js
+++ b/p2p.js
@@ -4,6 +4,17 @@ import { tcp } from '@libp2p/tcp'
 import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
 import debug from 'debug'
+import { multiaddr } from '@multiformats/multiaddr'
+import { Dagula } from './index.js'
+import { BitswapFetcher } from './bitswap-fetcher.js'
+
+/**
+ * @typedef {import('./index').BlockDecoders} BlockDecoders
+ * @typedef {import('./index').MultihashHashers} MultihashHashers
+ */
+
+const BITSWAP_PROTOCOL = '/ipfs/bitswap/1.2.0'
+const ELASTIC_IPFS = multiaddr('/dns4/elastic.dag.house/tcp/443/wss/p2p/bafzbeibhqavlasjc7dvbiopygwncnrtvjd2xmryk5laib7zyjor6kf3avm')
 
 const log = debug('dagula:p2p')
 
@@ -16,4 +27,23 @@ export async function getLibp2p () {
   await libp2p.start()
   log(libp2p.peerId.toString())
   return libp2p
+}
+
+/**
+   * @param {import('./index').Network} network
+   * @param {{ decoders?: BlockDecoders, hashers?: MultihashHashers, peer?: import('@multiformats/multiaddr').Multiaddr }} [options]
+   */
+export async function fromNetwork (network, options = {}) {
+  const peer = (typeof options.peer === 'string' ? multiaddr(options.peer) : options.peer) || ELASTIC_IPFS
+  const bitswap = new BitswapFetcher(async () => {
+    log('new stream to %s', peer)
+    // @ts-ignore
+    const stream = await network.dialProtocol(peer, BITSWAP_PROTOCOL, { lazy: true })
+    return stream
+  }, options)
+
+  // incoming blocks
+  await network.handle(BITSWAP_PROTOCOL, bitswap.handler)
+
+  return new Dagula(bitswap, options)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@libp2p/mplex": "^7.1.1",
         "@libp2p/tcp": "^6.0.9",
         "@libp2p/websockets": "^5.0.3",
+        "@multiformats/blake2": "^1.0.13",
         "@multiformats/multiaddr": "^11.3.0",
         "archy": "^1.0.0",
         "conf": "^11.0.1",
@@ -34,7 +35,8 @@
         "protobufjs": "^7.0.0",
         "sade": "^1.8.1",
         "streaming-iterables": "^7.0.4",
-        "timeout-abort-controller": "^3.0.0"
+        "timeout-abort-controller": "^3.0.0",
+        "varint": "^6.0.0"
       },
       "bin": {
         "dagula": "bin.js"
@@ -977,6 +979,20 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@multiformats/blake2": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
+      "integrity": "sha512-T1Kzya0wjj85CaVeRSpJ858EnSvW1pw94GSitxYf84VsNdv5XYbJ6QG8y26Ft1bVALzrUCmqkQrR53QHSyu6RA==",
+      "dependencies": {
+        "blakejs": "^1.1.1",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@multiformats/blake2/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/@multiformats/mafmt": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.0.3.tgz",
@@ -1653,6 +1669,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "node_modules/blockstore-core": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "ava": "^4.3.1",
         "blockstore-core": "^1.0.5",
         "ipfs-unixfs": "^11.0.0",
-        "miniswap": "^2.0.0",
+        "miniswap": "^2.0.1",
         "standard": "^17.0.0",
         "uint8arrays": "^3.0.0"
       }
@@ -119,27 +119,27 @@
       "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
     },
     "node_modules/@chainsafe/libp2p-noise": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.0.tgz",
-      "integrity": "sha512-NEl5aIv6muz9OL+dsa3INEU89JX0NViBxOy7NwwG8eNRPUDHo5E3ZTMSHXQpVx1K/ofoNS4ANO9xwezY6ss5GA==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.4.tgz",
+      "integrity": "sha512-X7kA6a3/QPFxNFwgUJ8vubDu5qBDcDT0nhD+jL7g60IFKZu//HFH7oqsNCZa12yx0oR1fEYOR62iHDt2GHyWBQ==",
       "dependencies": {
-        "@libp2p/crypto": "^1.0.0",
-        "@libp2p/interface-connection-encrypter": "^3.0.0",
-        "@libp2p/interface-keys": "^1.0.2",
-        "@libp2p/interface-metrics": "^4.0.2",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^3.0.5",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
         "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/logger": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
         "@libp2p/peer-id": "^2.0.0",
         "@stablelib/chacha20poly1305": "^1.0.1",
         "@stablelib/hkdf": "^1.0.1",
         "@stablelib/sha256": "^1.0.1",
-        "@stablelib/x25519": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3",
         "it-length-prefixed": "^8.0.2",
         "it-pair": "^2.0.2",
-        "it-pb-stream": "^2.0.2",
+        "it-pb-stream": "^3.2.0",
         "it-pipe": "^2.0.3",
         "it-stream-types": "^1.0.4",
-        "protons-runtime": "^4.0.1",
+        "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.3.2",
         "uint8arrays": "^4.0.2"
       },
@@ -160,15 +160,47 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
+      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.1",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -205,6 +237,15 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/@eslint/js": {
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
+      "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -239,9 +280,9 @@
       "dev": true
     },
     "node_modules/@ipld/car": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.0.3.tgz",
-      "integrity": "sha512-omPSY65OSVmlFGJDn2xbd75o71GNHmgP5u2dQ5fITc0X/QqJZVfZi95NCs8oa1wWhjkaK3RTswRSg2iNqFUSAg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.1.tgz",
+      "integrity": "sha512-HoFTUqUJL9cPGhC9qRmHCvamfIsj1JllQSQ/Xu9/KN/VNJp8To9Ms4qiZPEMOwcrNFclfYqrahjGYbf4KL/d9A==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
@@ -267,9 +308,9 @@
       }
     },
     "node_modules/@ipld/dag-json": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.0.tgz",
-      "integrity": "sha512-u/PfR2sT9AiZZDUl1VNspx3OP13zuvBXAd3sKiURlSOoWfoLigxTCs+sXeaXA0hoXU7u1M2DECMt4LCUHuApSA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
+      "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
       "dependencies": {
         "cborg": "^1.10.0",
         "multiformats": "^11.0.0"
@@ -280,9 +321,9 @@
       }
     },
     "node_modules/@ipld/dag-pb": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.0.tgz",
-      "integrity": "sha512-8FB/qTlNowCiszL9Sek8xH6xIQxIioXuzZ5B1jVPknQMVkd08nZUHzDjrn1Y6MqJ5PrXWLrBwNghGMWPPpvNVw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+      "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
       "dependencies": {
         "multiformats": "^11.0.0"
       },
@@ -292,17 +333,18 @@
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.11.tgz",
-      "integrity": "sha512-DWiG/0fKIDnkhTF3HoCu2OzkuKXysR/UKGdM9JZkT6F9jS9rwZYEwmacs4ybw1qyufyH+pMXV3/vuUu2Q/UxLw==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.15.tgz",
+      "integrity": "sha512-5X7K0eXmq1wJJqjYn6bJnGeanQHrkOnJawoRgCRfzgbQS5h+BK1lVSpJEBHoe/IU6aqsnDNrkPSE5cOffgz6+A==",
       "dependencies": {
         "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
         "@noble/ed25519": "^1.6.0",
         "@noble/secp256k1": "^1.5.4",
-        "err-code": "^3.0.1",
         "multiformats": "^11.0.0",
         "node-forge": "^1.1.0",
-        "protons-runtime": "^4.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
         "uint8arrays": "^4.0.2"
       },
       "engines": {
@@ -323,12 +365,42 @@
       }
     },
     "node_modules/@libp2p/interface-address-manager": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-2.0.4.tgz",
-      "integrity": "sha512-RcSi+z+xpVKJXq3BsfLf2rq8zb8VTAFown6uJBu02towMc0enYqqhwlV9DxcCaC573MgQ7gY2s/3XvxQdFraVA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-address-manager/-/interface-address-manager-2.0.5.tgz",
+      "integrity": "sha512-e2vLstKkYlAG2PZe6SEBpnnP2Y/ej6URue+zAiyjJPuXoOGNzHyLaqcv7MKye171OEf9dg5wv1gFphWcUJJbSA==",
       "dependencies": {
         "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-address-manager/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-address-manager/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -336,13 +408,13 @@
       }
     },
     "node_modules/@libp2p/interface-connection": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
-      "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.1.1.tgz",
+      "integrity": "sha512-+hxfYLv4jf+MruQEJiJeIyo/wI33/53wRL0XJTkxwQQPAkLHfZWCUY4kY9sXALd3+ASjXAENvJj9VvzZTlkRDQ==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
         "it-stream-types": "^1.0.4",
         "uint8arraylist": "^2.1.2"
       },
@@ -366,14 +438,90 @@
       }
     },
     "node_modules/@libp2p/interface-connection-manager": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.3.7.tgz",
-      "integrity": "sha512-GyRa7FXtwjbch4ucFa/jj6vcaQT2RyhUbH3q0tIOTzjntABTMzQrhn3BWOGU5deRp2K7cVOB/OzrdhHdGUxYQA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.5.0.tgz",
+      "integrity": "sha512-luqYVMH3yip12JlSwVmBdo5/qG4YnXQXp2AV4lvxWK0sUhCnI2r3YL4e9ne8o3LAA5CkH3lPqTQ2HSRpmOruFg==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-manager/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-manager/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-manager/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -381,9 +529,9 @@
       }
     },
     "node_modules/@libp2p/interface-content-routing": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.1.tgz",
-      "integrity": "sha512-M3rYXMhH+102qyZzc0GzkKq10x100nWVXGns2qtN3O82Hy/6FxXdgLUGIGWMdCj/7ilaVAuTwx8V3+DGmDIiMw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.2.tgz",
+      "integrity": "sha512-SlyZnBk+IpTKdT/4RMNTHcl18PRWUXfb3qhkBPP8xBNGm57DxApKQjLjoklSRNwJ3VDmXyPqTpiR/K/pLPow6A==",
       "dependencies": {
         "@libp2p/interface-peer-info": "^1.0.0",
         "@libp2p/interfaces": "^3.0.0",
@@ -411,9 +559,9 @@
       }
     },
     "node_modules/@libp2p/interface-keychain": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.3.tgz",
-      "integrity": "sha512-qtSUww/lpnrDHYMAOGDz5KLuTrHNM15kyuLqop96uN22V7PDizvkHY4EgtqWKgPLoNyeEnMwfUSBOQbXcWuVUA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.4.tgz",
+      "integrity": "sha512-RCH0PL9um/ejsPiWIOzxFzjPzL2nT2tRUtCDo1aBQqoBi7eYp4I4ya1KbzgWDPTmNuuFtCReRMQsZ7/KVirKPA==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "multiformats": "^11.0.0"
@@ -433,11 +581,11 @@
       }
     },
     "node_modules/@libp2p/interface-libp2p": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-1.1.1.tgz",
-      "integrity": "sha512-cELZZv/tzFxbUzL3Jvbk+AM2J6kDhIUNBIMMMLuR3LIHfmVJkh31G3ChLUZuKhBwB8wXJ1Ssev3fk1tfz/5DWA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-libp2p/-/interface-libp2p-1.3.3.tgz",
+      "integrity": "sha512-7kEoIlAGTIiUNJ/4vIFWx+j+iN4aco7O2PqH6ES3dTvX6sgvYxYFi83p1G/RDj8tHKO7jLfG3UmiwJc/Ab0VyA==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-connection": "^5.0.0",
         "@libp2p/interface-content-routing": "^2.0.0",
         "@libp2p/interface-dht": "^2.0.0",
         "@libp2p/interface-keychain": "^2.0.0",
@@ -446,10 +594,97 @@
         "@libp2p/interface-peer-info": "^1.0.0",
         "@libp2p/interface-peer-routing": "^1.0.0",
         "@libp2p/interface-peer-store": "^1.0.0",
-        "@libp2p/interface-pubsub": "^3.0.0",
+        "@libp2p/interface-pubsub": "^4.0.0",
         "@libp2p/interface-registrar": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p/node_modules/@libp2p/interface-connection": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.0.1.tgz",
+      "integrity": "sha512-SnGIXQLMydRh+xuuGNI7BPHfZ6+jn0z5FKKiCrUZ4vJBqnsyBQoEsg24Z+dl9P9JSRRRuYUcfJexBirInNf92w==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p/node_modules/@libp2p/interface-peer-store": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.9.tgz",
+      "integrity": "sha512-jAAlbP1NXpEJOG6Dbr0QdP71TBYjHBc/65Ulwdn4J4f04PW1bI4JIMQeq6+/sLfaGVryvvUT/a52io8UUtB21Q==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-record": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p/node_modules/@libp2p/interface-pubsub": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-4.0.0.tgz",
+      "integrity": "sha512-BvyQv1v6OZhKb+U/xpWz278Qsq+KDh4iMzIOq8HQr9lABrRDQWz0pTgeg5qCnChg+5eJW7K5BYFAgcpAf5zo4g==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-pushable": "^3.1.3",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-libp2p/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -457,11 +692,66 @@
       }
     },
     "node_modules/@libp2p/interface-metrics": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.7.tgz",
+      "integrity": "sha512-8z243/dHSPRELCSx30IJQpvn6Ci5UU1tnTPVLaqR6KrEL1DQb7v+c9RQjsaMnT8J+QjjviqcXxRbd6CTLYi+tQ==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0"
+        "@libp2p/interface-connection": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics/node_modules/@libp2p/interface-connection": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.0.1.tgz",
+      "integrity": "sha512-SnGIXQLMydRh+xuuGNI7BPHfZ6+jn0z5FKKiCrUZ4vJBqnsyBQoEsg24Z+dl9P9JSRRRuYUcfJexBirInNf92w==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -494,12 +784,42 @@
       }
     },
     "node_modules/@libp2p/interface-peer-info": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
-      "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.9.tgz",
+      "integrity": "sha512-XewuwXMVYMcwaxhH9PFVfsFNEXi2OEe9TgkBwvZbbtwTI2Cz6zvKS1tT4f+ATCXjQbN840Nhe6ETPQ4TfhThOQ==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-info/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -507,9 +827,9 @@
       }
     },
     "node_modules/@libp2p/interface-peer-routing": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.7.tgz",
-      "integrity": "sha512-0zxOOmKD6nA3LaArcP9UdRO4vJzEyoRtE34vvQP41UxjcSTaj4em5Fl4Q0RuOMXYPtRp+LdXRYbjJgCSeQoxwA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-routing/-/interface-peer-routing-1.0.8.tgz",
+      "integrity": "sha512-ArJWymWvHqVNyHSZ+7T9av2A4r0f1zTPMKe3+7BOX3n2mB8hP2nNMz/Kiun41TH0t80zMiXE73ZD29is27yt9g==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.0",
@@ -521,15 +841,44 @@
       }
     },
     "node_modules/@libp2p/interface-peer-store": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.8.tgz",
-      "integrity": "sha512-FM9VLmpg9CUBKZ2RW+J7RrQfQVMksLiC8oqENqHgb/VkPJY3kafbn7HIi0NcK6H/H5VcwBIhL15SUJk66O1K6g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-2.0.1.tgz",
+      "integrity": "sha512-y2JNTbn/kav0JyaEcCN4BFEJwjRIe6AoNDaWl6C69ioGOBykVzTS2MA64u9y+oaj7uSgt4AkZEIWNDFXlz74mA==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.0",
-        "@libp2p/interface-record": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-store/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-peer-store/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -537,15 +886,61 @@
       }
     },
     "node_modules/@libp2p/interface-pubsub": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
-      "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.7.tgz",
+      "integrity": "sha512-+c74EVUBTfw2sx1GE/z/IjsYO6dhur+ukF0knAppeZsRQ1Kgg6K5R3eECtT28fC6dBWLjFpAvW/7QGfiDAL4RA==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "it-pushable": "^3.0.0",
         "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-pubsub/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-pubsub/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-pubsub/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -566,11 +961,11 @@
       }
     },
     "node_modules/@libp2p/interface-registrar": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.8.tgz",
-      "integrity": "sha512-WbnXB09QF41zZzNgDUAZrRMilqgB7wBMTsSvql8xdDcws+jbaX4wE0iEpRXg1hyd0pz4mooIcMRaH1NiEQ5D8w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-registrar/-/interface-registrar-2.0.10.tgz",
+      "integrity": "sha512-niuU/ksbvnYyXnjstKCpPdFuRbJQQ6ISGF0rQVk5P9jhk4e1FvLHF197+rXloQkCFF+UxPKz5kmO8QmICM2xhg==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interface-peer-id": "^2.0.0"
       },
       "engines": {
@@ -578,12 +973,58 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-stream-muxer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
-      "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
+    "node_modules/@libp2p/interface-registrar/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-registrar/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-registrar/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.6.tgz",
+      "integrity": "sha512-wbLrH/bdF8qe0CpPd3BFMSmUs085vc3/8zx5uhXJySD672enAc8Jw9gmAYd1pIqELdqJqBDg9EI0y1XMRxvVkw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interfaces": "^3.0.0",
         "it-stream-types": "^1.0.4"
       },
@@ -592,16 +1033,108 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-transport": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.1.tgz",
-      "integrity": "sha512-xDM/s8iPN/XfNqD9qNelibRMPKkhOLinXwQeNtoTZjarq+Cg6rtO6/5WBG/49hyI3+r+5jd2eykjPGQbb86NFQ==",
+    "node_modules/@libp2p/interface-stream-muxer/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.3.tgz",
+      "integrity": "sha512-ez+0X+w2Wyw3nJY6mP0DHFgrRnln/miAH4TJLcRfUSJHjGXH5ZfpuK1TnRxXpEUiqOezSbwke06/znI27KpRiQ==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interface-stream-muxer": "^3.0.0",
         "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
         "it-stream-types": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -618,13 +1151,13 @@
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.5.tgz",
-      "integrity": "sha512-WEhxsc7+gsfuTcljI4vSgW/H2f18aBaC+JiO01FcX841Wxe9szjzHdBLDh9eqygUlzoK0LEeIBfctN7ibzus5A==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.7.tgz",
+      "integrity": "sha512-Zp9C9lMNGfVFTMVc7NvxuxMvIE6gyxDapQc/TqZH02IuIDl1JpZyCgNILr0APd8wcUxwvwRXYNf3kQ0Lmz7tuQ==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "debug": "^4.3.3",
-        "interface-datastore": "^7.0.0",
+        "interface-datastore": "^8.0.0",
         "multiformats": "^11.0.0"
       },
       "engines": {
@@ -633,22 +1166,56 @@
       }
     },
     "node_modules/@libp2p/mplex": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.1.tgz",
-      "integrity": "sha512-0owK1aWgXXtjiohXtjwLV7Ehjdj96eBtsapVt7AzlHA+W8uYnI+x058thq3MisyMDlHiiE3BTh6fEf+t2/0dUw==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.7.tgz",
+      "integrity": "sha512-8eJ6HUL3bM8ck0rb/NJ04+phBUVBMocxH/kuc2Nypn8RX9ezihV7srGGhG5N7muaMwJrRbYkFhIV4GH+8WTZUg==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.1",
+        "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
         "abortable-iterator": "^4.0.2",
-        "any-signal": "^3.0.0",
+        "any-signal": "^4.0.1",
         "benchmark": "^2.1.4",
-        "err-code": "^3.0.1",
         "it-batched-bytes": "^1.0.0",
         "it-pushable": "^3.1.0",
         "it-stream-types": "^1.0.4",
         "rate-limiter-flexible": "^2.3.9",
         "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
         "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
       },
@@ -670,26 +1237,97 @@
       }
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.2.tgz",
-      "integrity": "sha512-NfF0fwQM4sqiLuNGBVc9z2mfz3OigOfyLJ5zekRBGYHkbKWrBRFS3FligUPr9roCOzH6ojjDkKVd5aK9/llfJQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-3.1.8.tgz",
+      "integrity": "sha512-Ap6b3+69+j4R3KbqlQsHaa2OHGc2+YwwJcGU+VdiRS+RDM5mQdOjG0mGW2mRFDwrQKq9UZIkxo8hwzCZNkxFjA==",
       "dependencies": {
-        "@libp2p/interfaces": "^3.0.2",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
-        "it-first": "^2.0.0",
-        "it-handshake": "^4.1.2",
-        "it-length-prefixed": "^8.0.3",
-        "it-merge": "^2.0.0",
-        "it-pipe": "^2.0.4",
+        "abortable-iterator": "^5.0.0",
+        "it-first": "^3.0.1",
+        "it-handshake": "^4.1.3",
+        "it-length-prefixed": "^9.0.0",
+        "it-merge": "^3.0.0",
+        "it-pipe": "^3.0.0",
         "it-pushable": "^3.1.0",
         "it-reader": "^6.0.1",
-        "it-stream-types": "^1.0.4",
-        "p-defer": "^4.0.0",
+        "it-stream-types": "^2.0.1",
         "uint8arraylist": "^2.3.1",
         "uint8arrays": "^4.0.2"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "dependencies": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/it-first": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.1.tgz",
+      "integrity": "sha512-gEKSelg0HdApXCQ93m/vlJ1eqOXMlZ02kk/vOeDDOJcaSovo3enYbelUMKoDXljt4NUkeaqI4/WGtslF9nZEng==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/it-length-prefixed": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
+      "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/it-merge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.0.tgz",
+      "integrity": "sha512-sM7t9wPDvCJnAlnvTvzvx82j89GR4mmYs1F8e4tSZ6yChlrnymb1v3b8tXZ6lhZpTye2Nm5nN7zmlhfU5bv4qA==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -708,9 +1346,9 @@
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.0.tgz",
-      "integrity": "sha512-rVhfDmkVzfBVR4scAfaKb05htZENx01PYt2USi1EnODyoo2c2U2W5tfOfyaKI/4D+ayQDOjT27G0ZCyAgwkYGw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-3.0.1.tgz",
+      "integrity": "sha512-tJvCjFSKX76VacThVnN0XC4jnUeufYD2u9TxWJllSYnmmos/Lwhl4kdtEyZkKNlJKam+cBoUmODXzasdoPZgVg==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/peer-id": "^2.0.0"
@@ -721,9 +1359,9 @@
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.1.tgz",
-      "integrity": "sha512-uGIR4rS+j+IzzIu0kih4MonZEfRmjGNfXaSPMIFOeMxZItZT6TIpxoVNYxHl4YtneSFKzlLnf9yx9EhRcyfy8Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.3.tgz",
+      "integrity": "sha512-eZX+5ByUAzh8DrfjCan0spZGpvF7SxEBz4tOPoBMBCuKJJLr+8EokBO/5E3ceIw04f5+lAcD3CO3bccuKomp3Q==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.2.0",
@@ -736,16 +1374,16 @@
       }
     },
     "node_modules/@libp2p/peer-id-factory": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.1.tgz",
-      "integrity": "sha512-CRJmqwNQhDC51sQ9lf6EqEY8HuywwymMVffL2kIYI5ts5k+6gvIXzoSxLf3V3o+OxcroXG4KG0uGxxAi5DUXSA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-2.0.3.tgz",
+      "integrity": "sha512-9pwVbfghiKuiC76Pue/+tI4PD7gnw1jGVcxYD+nhcRs8ABE7NLaB7nCm99cCtvmMNRnl2JqaGgZJXt8mnvAEuQ==",
       "dependencies": {
         "@libp2p/crypto": "^1.0.0",
         "@libp2p/interface-keys": "^1.0.2",
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/peer-id": "^2.0.0",
         "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
+        "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.0.0",
         "uint8arrays": "^4.0.2"
       },
@@ -779,49 +1417,40 @@
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.0.tgz",
-      "integrity": "sha512-qGaqYQSRqI/vol1NEMR9Z3ncLjIkyIF0o/CQYXzXCDjA91i9+0iMjXGgIgBLn3bfA1b9pHuz4HvwjgYUKMYOkQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-5.0.3.tgz",
+      "integrity": "sha512-KnQR/NteL0xGKXd9rZo/W3ZT9kajmNy98/BOOlnMktkAL7jCfHy2z/laDU+rSttTy1TYZ15zPzXtnm3813ECmg==",
       "dependencies": {
         "@libp2p/crypto": "^1.0.11",
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-record": "^2.0.1",
-        "@libp2p/logger": "^2.0.5",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/peer-id": "^2.0.0",
         "@libp2p/utils": "^3.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^7.0.0",
-        "it-all": "^2.0.0",
-        "it-filter": "^2.0.0",
-        "it-foreach": "^1.0.0",
-        "it-map": "^2.0.0",
-        "it-pipe": "^2.0.3",
-        "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
+        "@multiformats/multiaddr": "^12.0.0",
+        "protons-runtime": "^5.0.0",
         "uint8-varint": "^1.0.2",
         "uint8arraylist": "^2.1.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/peer-record/node_modules/it-all": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/it-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.0.tgz",
-      "integrity": "sha512-E68+zzoNNI7MxdH1T4lUTgwpCyEnymlH349Qg2mcvsqLmYRkaZLM4NfZZ0hUuH7/5DkWXubQSDOYH396va8mpg==",
+    "node_modules/@libp2p/peer-record/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -840,29 +1469,27 @@
       }
     },
     "node_modules/@libp2p/peer-store": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.0.tgz",
-      "integrity": "sha512-7GSqRYkJR3E0Vo96XH84X6KNPdwOE1t6jb7jegYzvzKDZMFaceJUZg9om3+ZHCUbethnYuqsY7j0c7OHCB40nA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-6.0.4.tgz",
+      "integrity": "sha512-yw7XbeJ5k880PpkDV/HcSZtj0vQ0ShPbnCzVHc1hW0JS/g1vhpSooAZOf3w65obUoFhUwccnSZ4HSLBSpQqOaA==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interface-peer-info": "^1.0.3",
         "@libp2p/interface-peer-store": "^1.2.2",
         "@libp2p/interface-record": "^2.0.1",
-        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/peer-id": "^2.0.0",
         "@libp2p/peer-record": "^5.0.0",
         "@multiformats/multiaddr": "^11.0.0",
-        "err-code": "^3.0.1",
         "interface-datastore": "^7.0.0",
         "it-all": "^2.0.0",
         "it-filter": "^2.0.0",
         "it-foreach": "^1.0.0",
         "it-map": "^2.0.0",
-        "it-pipe": "^2.0.3",
         "mortice": "^3.0.0",
         "multiformats": "^11.0.0",
-        "protons-runtime": "^4.0.1",
+        "protons-runtime": "^5.0.0",
         "uint8arraylist": "^2.1.1",
         "uint8arrays": "^4.0.2"
       },
@@ -871,19 +1498,76 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/interface-peer-store": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.9.tgz",
+      "integrity": "sha512-jAAlbP1NXpEJOG6Dbr0QdP71TBYjHBc/65Ulwdn4J4f04PW1bI4JIMQeq6+/sLfaGVryvvUT/a52io8UUtB21Q==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-record": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/interface-peer-store/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@libp2p/peer-store/node_modules/it-all": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/it-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.0.tgz",
-      "integrity": "sha512-E68+zzoNNI7MxdH1T4lUTgwpCyEnymlH349Qg2mcvsqLmYRkaZLM4NfZZ0hUuH7/5DkWXubQSDOYH396va8mpg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.2.tgz",
+      "integrity": "sha512-gocw1F3siqupegsOzZ78rAc9C+sYlQbI2af/TmzgdrR613MyEJHbvfwBf12XRekGG907kqXSOGKPlxzJa6XV1Q==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -902,19 +1586,65 @@
       }
     },
     "node_modules/@libp2p/tcp": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-6.0.9.tgz",
-      "integrity": "sha512-zQ7J8NeyOw/7SxNmtkA1aNFxHOCtxdhZ/5SZcZoUD3HDYnAsRpS+RMPICpoMRct1o5wGFhNfumB6beZ3ZBBn+Q==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-6.2.2.tgz",
+      "integrity": "sha512-5pLQDSUI+6qtAvh7pYgjqXFuFqzZ/AGL3BSX4C2oa+vWGIbooTZK3Mizp+iO0yHomVJ1y3V8AXXH8ddWdFqDpQ==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interface-metrics": "^4.0.0",
         "@libp2p/interface-transport": "^2.0.0",
         "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
-        "@multiformats/mafmt": "^11.0.3",
-        "@multiformats/multiaddr": "^11.0.0",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
         "stream-to-it": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/tcp/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/tcp/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/tcp/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -934,19 +1664,19 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.4.tgz",
-      "integrity": "sha512-EWJNJtlop2ylmGE1BNiMA0u4eTLKoY0LbZ/DOvSDs9VlGSLua9J+LUjp6XV8lazGv7l1rOLiU+1hP5fcmg1+eg==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.11.tgz",
+      "integrity": "sha512-d8ZQnu2o78TG7Oy4G6qFy5v/kNBtfgQjy1RpiQAEAB6AOSi1Oq8nLebrgCqSHfrtOIcj6a+G6ImYBaRE4b03CA==",
       "dependencies": {
         "@achingbrain/ip-address": "^8.1.0",
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-peer-store": "^1.2.1",
+        "@libp2p/interface-connection": "^5.0.1",
+        "@libp2p/interface-peer-store": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
         "@libp2p/logger": "^2.0.0",
-        "@multiformats/multiaddr": "^11.0.0",
-        "abortable-iterator": "^4.0.2",
-        "err-code": "^3.0.1",
+        "@multiformats/multiaddr": "^12.0.0",
+        "abortable-iterator": "^5.0.0",
         "is-loopback-addr": "^2.0.1",
-        "it-stream-types": "^1.0.4",
+        "it-stream-types": "^2.0.1",
         "private-ip": "^3.0.0",
         "uint8arraylist": "^2.3.2"
       },
@@ -955,24 +1685,139 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/websockets": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.3.tgz",
-      "integrity": "sha512-/0ie47LEKU5VVeaeE/T6UbvaZbUSmyWXu4KcojY+zl809oONFjagKuZB6T7jJQqAV7WCq7O+ulC2tFOwbID08w==",
+    "node_modules/@libp2p/utils/node_modules/@libp2p/interface-connection": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.0.1.tgz",
+      "integrity": "sha512-SnGIXQLMydRh+xuuGNI7BPHfZ6+jn0z5FKKiCrUZ4vJBqnsyBQoEsg24Z+dl9P9JSRRRuYUcfJexBirInNf92w==",
       "dependencies": {
-        "@libp2p/interface-connection": "^3.0.2",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "dependencies": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/utils/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.10.tgz",
+      "integrity": "sha512-q8aKm0rhDxZjc4TzDpB0quog4pViFnz+Ok+UbGEk3xXxHwT3QCxaDVPKMemMqN/1N3OahVvcodpcvFSuWmus+A==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interface-transport": "^2.0.0",
         "@libp2p/interfaces": "^3.0.3",
         "@libp2p/logger": "^2.0.0",
         "@libp2p/utils": "^3.0.2",
-        "@multiformats/mafmt": "^11.0.3",
-        "@multiformats/multiaddr": "^11.0.0",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
         "@multiformats/multiaddr-to-uri": "^9.0.2",
         "abortable-iterator": "^4.0.2",
         "it-ws": "^5.0.6",
         "p-defer": "^4.0.0",
         "p-timeout": "^6.0.0",
-        "wherearewe": "^2.0.1"
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -994,11 +1839,41 @@
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/@multiformats/mafmt": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.0.3.tgz",
-      "integrity": "sha512-DvCQeZJgaC4kE3BLqMuW3gQkNAW14Z7I+yMt30Ze+wkfHkWSp+bICcHGihhtgfzYCumHA/vHlJ9n54mrCcmnvQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.0.tgz",
+      "integrity": "sha512-P3+cKi0EqqYGoF8IMK7dd8PFlanbvzzhem+tkcjrjGAPV5sVam2VfFAFNyzLTOP8dS/5Rf5pQ6LC0k6cO8WF5w==",
       "dependencies": {
-        "@multiformats/multiaddr": "^11.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/mafmt/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/mafmt/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1006,9 +1881,9 @@
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.3.0.tgz",
-      "integrity": "sha512-Inrmp986nHe92pgYyOWNVnB8QDmYe5EhR/7TStc46O4YEm87pbc1i4DWiTlEJ6tOpL8V6IBH5ol8BZsIaN+Tww==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
@@ -1023,11 +1898,41 @@
       }
     },
     "node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.2.tgz",
-      "integrity": "sha512-vrWmfFadmix5Ab9l//oRQdQ7O3J5bGJpJRMSm21bHlQB0XV4xtNU6vMZBVXeu3Su79LgflEp37cjTFE3yKf3Hw==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.4.tgz",
+      "integrity": "sha512-y2XDH/h6U1hnkFNyt3NeJhUv+9PiXJlzC6RZOOzK2OY3JgM6l6RrPrOJ1Tc2Sn4Aw6b2aUKY4C6nN4h6j9/+Vg==",
       "dependencies": {
-        "@multiformats/multiaddr": "^11.0.0"
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1060,9 +1965,9 @@
       }
     },
     "node_modules/@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
       "funding": [
         {
           "type": "individual",
@@ -1303,9 +2208,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+      "version": "18.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
+      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
     },
     "node_modules/@types/retry": {
       "version": "0.12.1",
@@ -1313,18 +2218,18 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "node_modules/abortable-iterator": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-4.0.2.tgz",
-      "integrity": "sha512-SJGELER5yXr9v3kiL6mT5RZ1qlyJ9hV4nm34+vfsdIM1lp3zENQvpsqKgykpFLgRMUn3lzlizLTpiOASW05/+g==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-4.0.3.tgz",
+      "integrity": "sha512-GJ5fyS9O0hK/TMf+weR+WMEwSEBWVuStHqHmUYWbfHPULyVf7QdUnAvh41+1cUWtHVf0Z/qtQynidxz4ZFDPOg==",
       "dependencies": {
         "get-iterator": "^2.0.0",
         "it-stream-types": "^1.0.3"
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1423,9 +2328,13 @@
       }
     },
     "node_modules/any-signal": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
-      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -1450,6 +2359,19 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/array-find-index": {
       "version": "1.0.2",
@@ -1559,11 +2481,11 @@
       }
     },
     "node_modules/atomically": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.0.tgz",
-      "integrity": "sha512-KpioFPR6tOK/u3z1tFplHI9l2yK3Nu8cl47gAsTfPT6i2UClTXoqOk8dZqGIwWWopen4bSP5HnlaPUDWC7IfKw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
+      "integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
       "dependencies": {
-        "stubborn-fs": "^1.2.1",
+        "stubborn-fs": "^1.2.4",
         "when-exit": "^2.0.0"
       }
     },
@@ -1795,9 +2717,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
-      "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.1.tgz",
+      "integrity": "sha512-et6Qm8MOUY2kCWa5GKk2MlBVoPjHv0hQBmlzI/Z7+5V3VJCeIkGehIB3vWknNsm2kOkAIs6wEKJFJo8luWQQ/w==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -1848,9 +2770,9 @@
       "dev": true
     },
     "node_modules/ci-info": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true,
       "funding": [
         {
@@ -2111,37 +3033,60 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/datastore-core/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/datastore-core/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/datastore-core/node_modules/it-all": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/datastore-core/node_modules/it-drain": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.0.tgz",
-      "integrity": "sha512-oa/5iyBtRs9UW486vPpyDTC0ee3rqx5qlrPI7txIUJcqqtiO5yVozEB6LQrl5ysQYv+P3y/dlKEqwVqlCV0SEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+      "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/datastore-core/node_modules/it-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.0.tgz",
-      "integrity": "sha512-E68+zzoNNI7MxdH1T4lUTgwpCyEnymlH349Qg2mcvsqLmYRkaZLM4NfZZ0hUuH7/5DkWXubQSDOYH396va8mpg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.2.tgz",
+      "integrity": "sha512-gocw1F3siqupegsOzZ78rAc9C+sYlQbI2af/TmzgdrR613MyEJHbvfwBf12XRekGG907kqXSOGKPlxzJa6XV1Q==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/datastore-core/node_modules/it-take": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.0.tgz",
-      "integrity": "sha512-lN3diSTomOvYBk2K0LHAgrQ52DlQfvq8tH/+HLAFpX8Q3JwBkr/BPJEi3Z3Lf8jMmN1KOCBXvt5sXa3eW9vUmg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.1.tgz",
+      "integrity": "sha512-DL7kpZNjuoeSTnB9dMAJ0Z3m2T29LRRAU+HIgkiQM+1jH3m8l9e/1xpWs8JHTlbKivbqSFrQMTc8KVcaQNmsaA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -2224,9 +3169,9 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
@@ -2430,18 +3375,18 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
@@ -2449,8 +3394,8 @@
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.4",
-        "is-array-buffer": "^3.0.1",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
@@ -2458,11 +3403,12 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
         "typed-array-length": "^1.0.4",
@@ -2538,12 +3484,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.39.0.tgz",
+      "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.4.1",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.39.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2553,11 +3502,10 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
@@ -2578,7 +3526,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -2664,9 +3611,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+      "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7"
@@ -2792,9 +3739,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.6.1.tgz",
-      "integrity": "sha512-R9xw9OtCRxxaxaszTQmQAlPgM+RdGjaL1akWuY/Fv9fRAi8Wj4CUKc6iYVG8QNRjRuo8/BqVYIpfqberJUEacA==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "dependencies": {
         "builtins": "^5.0.1",
@@ -2829,9 +3776,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.32.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.1.tgz",
-      "integrity": "sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==",
+      "version": "7.32.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.6",
@@ -2896,9 +3843,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2906,6 +3853,9 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-utils": {
@@ -2936,12 +3886,15 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -3125,14 +4078,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3155,9 +4108,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -3248,9 +4201,9 @@
       "dev": true
     },
     "node_modules/fast-fifo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.2.0.tgz",
+      "integrity": "sha512-NcvQXt7Cky1cNau15FWy64IjuO8X0JijhTBBrJj1YlxlDfRkJXNaK9RFUjwpfDPzMdv7wB38jr53l9tkNLxnWg=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -3445,9 +4398,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -3535,9 +4488,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.19.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3577,9 +4530,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
+      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
       "dev": true,
       "dependencies": {
         "dir-glob": "^3.0.1",
@@ -3620,9 +4573,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/grapheme-splitter": {
@@ -3847,11 +4800,11 @@
       "dev": true
     },
     "node_modules/interface-datastore": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.3.tgz",
-      "integrity": "sha512-6zUypd1LM2Rl8o58RgJ7stLHgqx5+9t0+XkUVAvjd3KkWCNKBknD7G+Zar5jpUGClS+IINRPTjH/8Xnc2HB39A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.0.tgz",
+      "integrity": "sha512-rDMAcpCGxWMubRk2YQuSEHl11bc0xcZeBZzfLvqhoZJdByUWeo7YDJUdgyRKgD6liGXVYirtDkFU9nyn9xl2hg==",
       "dependencies": {
-        "interface-store": "^3.0.0",
+        "interface-store": "^5.0.0",
         "nanoid": "^4.0.0",
         "uint8arrays": "^4.0.2"
       },
@@ -3861,9 +4814,9 @@
       }
     },
     "node_modules/interface-datastore/node_modules/interface-store": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.3.tgz",
-      "integrity": "sha512-FihzZamIkSPHIFw7xZAvZ77DEOSTvHt/t3HvIG7pm8lmqDIUh8/PgDsez/4Aa2091bT0sqK4tTFBcKF9TOGhtQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.0.tgz",
+      "integrity": "sha512-mjUwX3XSoreoxCS3sXS3pSRsGnUjl9T06KBqt/T7AgE9Sgp4diH64ZyURJKnj2T5WmCvTbC0Dm+mwQV5hfLSBQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -3888,12 +4841,12 @@
       "dev": true
     },
     "node_modules/internal-slot": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
-      "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
@@ -3984,9 +4937,9 @@
       }
     },
     "node_modules/ipfs-unixfs-exporter/node_modules/it-filter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
-      "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.2.tgz",
+      "integrity": "sha512-gocw1F3siqupegsOzZ78rAc9C+sYlQbI2af/TmzgdrR613MyEJHbvfwBf12XRekGG907kqXSOGKPlxzJa6XV1Q==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -4004,39 +4957,23 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipfs-unixfs/node_modules/protons-runtime": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
-      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
-      "dependencies": {
-        "protobufjs": "^7.0.0",
-        "uint8arraylist": "^2.4.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      },
-      "peerDependencies": {
-        "uint8arraylist": "^2.3.2"
-      }
-    },
     "node_modules/irregular-plurals": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
-      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
       },
       "funding": {
@@ -4102,9 +5039,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -4129,9 +5066,9 @@
       }
     },
     "node_modules/is-electron": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
-      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "node_modules/is-error": {
       "version": "2.2.2",
@@ -4386,9 +5323,9 @@
       "dev": true
     },
     "node_modules/it-batched-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.0.tgz",
-      "integrity": "sha512-OfztV9UHQmoZ6u5F4y+YOI1Z+5JAhkv3Gexc1a0B7ikcVXc3PFSKlEnHv79u+Yp/h23o3tsF9hHAhuqgHCYT2Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-batched-bytes/-/it-batched-bytes-1.0.1.tgz",
+      "integrity": "sha512-ptBiZ0Mh3kJYySpG0pCS7JgvWhaAW1fGfKDVFtNIuNTA+bpSlXINvD5H3b14ZlJbnJFzFzRSCSZ10E1nH4z/WQ==",
       "dependencies": {
         "it-stream-types": "^1.0.4",
         "p-defer": "^4.0.0",
@@ -4412,31 +5349,31 @@
       "dev": true
     },
     "node_modules/it-first": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
-      "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+      "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-foreach": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.0.tgz",
-      "integrity": "sha512-2j5HK1P6aMwEvgL6K5nzUwOk+81B/mjt05PxiSspFEKwJnqy1LfJYlLLS6llBoM+NdoUxf6EsBCHidFGmsXvhw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-1.0.1.tgz",
+      "integrity": "sha512-eaVFhKxU+uwPs7+DKYxjuL6pj6c50/MBlAH+XPMgPWRRVIChVoyEIsdUQkkC0Ad6oTUmJbKRTnJxEY6o2aIs7A==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-handshake": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-4.1.2.tgz",
-      "integrity": "sha512-Q/EvrB4KWIX5+/wO7edBK3l79Vh28+iWPGZvZSSqwAtOJnHZIvywC+JUbiXPRJVXfICBJRqFETtIJcvrqWL2Zw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-4.1.3.tgz",
+      "integrity": "sha512-V6Lt9A9usox9iduOX+edU1Vo94E6v9Lt9dOvg3ubFaw1qf5NCxXLi93Ao4fyCHWDYd8Y+DUhadwNtWVyn7qqLg==",
       "dependencies": {
         "it-pushable": "^3.1.0",
         "it-reader": "^6.0.1",
-        "it-stream-types": "^1.0.4",
+        "it-stream-types": "^2.0.1",
         "p-defer": "^4.0.0",
         "uint8arraylist": "^2.0.0"
       },
@@ -4445,10 +5382,19 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/it-handshake/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/it-last": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.0.tgz",
-      "integrity": "sha512-u0GHZ01tWYtPvDkOaqZSLLWjFv3IJw9cPL9mbEV7wnE8DOsbVoXIuKpnz3U6pySl5RzPVjTzSHOc961ZYttBxg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.1.tgz",
+      "integrity": "sha512-uVMedYW0wa2Cx0TAmcOCLbfuLLII7+vyURmhKa8Zovpd+aBTMsmINtsta2n364wJ5qsEDBH+akY1sUtAkaYBlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -4483,18 +5429,18 @@
       }
     },
     "node_modules/it-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
-      "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-merge": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.0.tgz",
-      "integrity": "sha512-mH4bo/ZrMoU+Wlu7ZuYPNNh9oWZ/GvYbeXZ0zll97+Rp6H4jFu98iu6v9qqXDz//RUjdO9zGh8awzMfOElsjpA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.1.tgz",
+      "integrity": "sha512-ItoBy3dPlNKnhjHR8e7nfabfZzH4Jy2OMPvayYH3XHy4YNqSVKmWTIxhz7KX4UMBsLChlIJZ+5j6csJgrYGQtw==",
       "dependencies": {
         "it-pushable": "^3.1.0"
       },
@@ -4504,11 +5450,11 @@
       }
     },
     "node_modules/it-pair": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.3.tgz",
-      "integrity": "sha512-heCgsbYscFCQY5YvltlGT9tjgLGYo7NxPEoJyl55X4BD2KOXpTyuwOhPLWhi9Io0y6+4ZUXCkyaQXIB6Y8xhRw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.6.tgz",
+      "integrity": "sha512-5M0t5RAcYEQYNG5BV7d7cqbdwbCAp5yLdzvkxsZmkuZsLbTdZzah6MQySYfaAQjNDCq6PUnDt0hqBZ4NwMfW6g==",
       "dependencies": {
-        "it-stream-types": "^1.0.3",
+        "it-stream-types": "^2.0.1",
         "p-defer": "^4.0.0"
       },
       "engines": {
@@ -4516,10 +5462,19 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/it-pair/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/it-parallel": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.0.tgz",
-      "integrity": "sha512-/y70cY7VoZ7natLbWrPxoRaKWMD67RvtWx21cyLJr6kkuHrUWOrHNr8CPMBqzDRh73aig/uUT82hzTTmTTkDUg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.2.tgz",
+      "integrity": "sha512-uPVVv0Ir/yq9p3jOSWusEY7IEBZh1TNT8M6xSxxlJ5kKaPl2ulN6PzSQOC+lZXGKGWU3rneQ3hN/cO06aM04zw==",
       "dependencies": {
         "p-defer": "^4.0.0"
       },
@@ -4529,14 +5484,54 @@
       }
     },
     "node_modules/it-pb-stream": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-2.0.3.tgz",
-      "integrity": "sha512-nuJzftDqk52gZmVD6T0sIKggXMhBkLSAFCD1OecxqGTVwk2wuDYY0ZHpcXZJuHty3kIuLY4xlWZrnDH9efV4YA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-3.2.1.tgz",
+      "integrity": "sha512-vKE04Zv5MUcwxPNE9bIEfYK3rd/Klj5ORGD1D8Bn5f0mbCLGfouSrqZP1Jntg2osqQg4BN5dKKS2BbfwyGUI3Q==",
       "dependencies": {
-        "it-handshake": "^4.1.2",
-        "it-length-prefixed": "^8.0.2",
+        "err-code": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pushable": "^3.1.2",
         "it-stream-types": "^1.0.4",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.6",
         "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pb-stream/node_modules/it-length-prefixed": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
+      "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pb-stream/node_modules/it-length-prefixed/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pb-stream/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -4558,20 +5553,20 @@
       }
     },
     "node_modules/it-pushable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.3.tgz",
+      "integrity": "sha512-f50iQ85HISS6DaWCyrqf9QJ6G/kQtKIMf9xZkgZgyOvxEQDfn8OfYcLXXquCqgoLboxQtAW1ZFZyFIAsLHDtJw==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/it-reader": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.2.tgz",
-      "integrity": "sha512-rQdVyml+r/2v8PQsPfJgf626tAkbA7NW1EF6zuucT2Ryy1U6YJtSuCJL8fKuDOyiR/mLzbfP0QQJlSeeoLph2A==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.4.tgz",
+      "integrity": "sha512-XCWifEcNFFjjBHtor4Sfaj8rcpt+FkY0L6WdhD578SCDhV4VUm7fCkF3dv5a+fTcfQqvN9BsxBTvWbYO6iCjTg==",
       "dependencies": {
-        "it-stream-types": "^1.0.4",
+        "it-stream-types": "^2.0.1",
         "uint8arraylist": "^2.0.0"
       },
       "engines": {
@@ -4579,10 +5574,19 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/it-reader/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/it-sort": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.0.tgz",
-      "integrity": "sha512-yeAE97b5PEjCrWFUiNyR90eJdGslj8FB3cjT84rsc+mzx9lxPyR2zJkYB9ZOJoWE5MMebxqcQCLRT3OSlzo7Zg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-2.0.1.tgz",
+      "integrity": "sha512-9f4jKOTHfxc/FJpg/wwuQ+j+88i+sfNGKsu2HukAKymm71/XDnBFtOAOzaimko3YIhmn/ERwnfEKrsYLykxw9A==",
       "dependencies": {
         "it-all": "^2.0.0"
       },
@@ -4592,9 +5596,9 @@
       }
     },
     "node_modules/it-sort/node_modules/it-all": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -4644,9 +5648,9 @@
       }
     },
     "node_modules/js-sdsl": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
-      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4824,31 +5828,139 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/libp2p/node_modules/@libp2p/interface-peer-store": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-store/-/interface-peer-store-1.2.9.tgz",
+      "integrity": "sha512-jAAlbP1NXpEJOG6Dbr0QdP71TBYjHBc/65Ulwdn4J4f04PW1bI4JIMQeq6+/sLfaGVryvvUT/a52io8UUtB21Q==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.0",
+        "@libp2p/interface-record": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/@libp2p/interface-peer-store/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/@multiformats/mafmt": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.1.2.tgz",
+      "integrity": "sha512-3n1o5eLU7WzTAPLuz3AodV7Iql6NWf7Ws8fqVaGT7o5nDDabUPYGBm2cZuh3OrqmwyCY61LrNUIsjzivU6UdpQ==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/@multiformats/mafmt/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.2.tgz",
+      "integrity": "sha512-EYYUEAddjWoyig5Dcu+JGq2JdpEpT2tW/K4sefdDWVSQW+rfnABfz1rx/KnrituB20jC8aPBcT62kISTZ3oL5A==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
+    },
+    "node_modules/libp2p/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/libp2p/node_modules/it-all": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
-      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/libp2p/node_modules/it-drain": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.0.tgz",
-      "integrity": "sha512-oa/5iyBtRs9UW486vPpyDTC0ee3rqx5qlrPI7txIUJcqqtiO5yVozEB6LQrl5ysQYv+P3y/dlKEqwVqlCV0SEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+      "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/libp2p/node_modules/it-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.0.tgz",
-      "integrity": "sha512-E68+zzoNNI7MxdH1T4lUTgwpCyEnymlH349Qg2mcvsqLmYRkaZLM4NfZZ0hUuH7/5DkWXubQSDOYH396va8mpg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.2.tgz",
+      "integrity": "sha512-gocw1F3siqupegsOzZ78rAc9C+sYlQbI2af/TmzgdrR613MyEJHbvfwBf12XRekGG907kqXSOGKPlxzJa6XV1Q==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/protons-runtime": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
+      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/libp2p/node_modules/uint8arrays": {
@@ -4876,9 +5988,9 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
-      "integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^6.0.0"
@@ -4902,9 +6014,9 @@
       "dev": true
     },
     "node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/longbits": {
       "version": "1.1.0",
@@ -5068,26 +6180,95 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/miniswap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/miniswap/-/miniswap-2.0.0.tgz",
-      "integrity": "sha512-5h9ncSZZ3FArGBkK3h+Kv73HedFtYbEFcXfkE5ecoJRwHubC+XSRpe5KFEPWZYW8eL2wh9Ru1fp9ps3tj3K0+A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/miniswap/-/miniswap-2.0.1.tgz",
+      "integrity": "sha512-2aZSXftF2v6iK99NWWwZWWGeY/30rZqFZslzI2wYWVXpZq67xWUjO8YQeWsNPvV9tohbxwsNmsib3G9mMcRi6A==",
       "dev": true,
       "dependencies": {
         "@libp2p/interface-registrar": "^2.0.8",
-        "it-length-prefixed": "^8.0.4",
-        "it-pipe": "^2.0.3",
+        "it-length-prefixed": "^9.0.1",
+        "it-pipe": "^3.0.1",
         "multiformats": "^11.0.1",
         "protobufjs": "^7.1.2",
-        "streaming-iterables": "^7.0.4"
+        "streaming-iterables": "^7.0.4",
+        "varint": "^6.0.0"
+      }
+    },
+    "node_modules/miniswap/node_modules/it-length-prefixed": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
+      "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
+      "dev": true,
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/miniswap/node_modules/it-merge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.0.tgz",
+      "integrity": "sha512-sM7t9wPDvCJnAlnvTvzvx82j89GR4mmYs1F8e4tSZ6yChlrnymb1v3b8tXZ6lhZpTye2Nm5nN7zmlhfU5bv4qA==",
+      "dev": true,
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/miniswap/node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dev": true,
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/miniswap/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/miniswap/node_modules/uint8arrays": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/mortice": {
@@ -5119,9 +6300,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multiformats": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
-      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -5136,9 +6317,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -5468,9 +6655,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
+      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
       "dependencies": {
         "eventemitter3": "^4.0.7",
         "p-timeout": "^5.0.2"
@@ -5535,9 +6722,9 @@
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-      "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+      "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w==",
       "engines": {
         "node": ">=14.16"
       },
@@ -5745,9 +6932,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
+      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -5768,9 +6955,9 @@
       }
     },
     "node_modules/protons-runtime": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
-      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+      "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
       "dependencies": {
         "protobufjs": "^7.0.0",
         "uint8arraylist": "^2.4.3"
@@ -5784,9 +6971,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
-      "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
         "node": ">=6"
       }
@@ -5843,14 +7030,14 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5889,12 +7076,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -6026,9 +7213,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6394,6 +7581,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -6467,9 +7671,9 @@
       }
     },
     "node_modules/stubborn-fs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.1.tgz",
-      "integrity": "sha512-IgTveO0OGXMMi9iZtfPoYQY6IpeZR3ILtSsjMapFgLxofWaHG1sNlInV7yTRDV06YiNdwiKrK7505Fxq8ly+YA=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
+      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
     },
     "node_modules/supertap": {
       "version": "3.0.1",
@@ -6591,13 +7795,13 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
@@ -6640,9 +7844,9 @@
       }
     },
     "node_modules/uint8-varint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.4.tgz",
-      "integrity": "sha512-FHnaReHRIM7kHe/Ms0I2KGkuSY4o7ouhUJGJeiFEuYWGvBt4Y64+BJ3mV6DqmyYtYTZj4Pz8K/BmViSNFLRrVw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-1.0.6.tgz",
+      "integrity": "sha512-Z0ujO4rxPwxTdLsSI5ke+bdl9hjJ1xiOakBPZeWUI/u6YBGCEGTW6b90SMlhxSGButKVPkL9fMFUDnqThQYTGg==",
       "dependencies": {
         "byte-access": "^1.0.0",
         "longbits": "^1.1.0",
@@ -6721,14 +7925,14 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.15.1.tgz",
-      "integrity": "sha512-XLk8g0WAngdvFqTI+VKfBtM4YWXgdxkf1WezC771Es0Dd+Pm1KmNx8t93WTC+Hh9tnghmVxkclU1HN+j+CvIUA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
       "engines": {
-        "node": ">=12.18"
+        "node": ">=14.0"
       }
     },
     "node_modules/uri-js": {
@@ -6767,9 +7971,9 @@
       }
     },
     "node_modules/when-exit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.0.0.tgz",
-      "integrity": "sha512-17lB0PWIgOuil9dgC/vdQY0aq5lwT0umemaIsOTNDBsc1TwclvocXOvkwenwUXEawN5mW3F64X52xPkTFnihDw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
+      "integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ=="
     },
     "node_modules/wherearewe": {
       "version": "2.0.1",
@@ -6944,9 +8148,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7012,9 +8216,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ava": "^4.3.1",
     "blockstore-core": "^1.0.5",
     "ipfs-unixfs": "^11.0.0",
-    "miniswap": "^2.0.0",
+    "miniswap": "^2.0.1",
     "standard": "^17.0.0",
     "uint8arrays": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@libp2p/mplex": "^7.1.1",
     "@libp2p/tcp": "^6.0.9",
     "@libp2p/websockets": "^5.0.3",
+    "@multiformats/blake2": "^1.0.13",
     "@multiformats/multiaddr": "^11.3.0",
     "archy": "^1.0.0",
     "conf": "^11.0.1",
@@ -42,7 +43,8 @@
     "protobufjs": "^7.0.0",
     "sade": "^1.8.1",
     "streaming-iterables": "^7.0.4",
-    "timeout-abort-controller": "^3.0.0"
+    "timeout-abort-controller": "^3.0.0",
+    "varint": "^6.0.0"
   },
   "devDependencies": {
     "ava": "^4.3.1",

--- a/prefix.js
+++ b/prefix.js
@@ -1,0 +1,41 @@
+import varint from 'varint'
+
+/**
+ * @typedef {{
+ *   version: number
+ *   code: number
+ *   multihash: {
+ *     code: number
+ *     size: number
+ *   }
+ * }} Prefix All the metadata of a CID.
+ * See https://github.com/ipfs/go-cid/blob/829c826f6be23320846f4b7318aee4d17bf8e094/cid.go#L542-L554
+ */
+
+/** @param {Prefix} prefix */
+export function encode (prefix) {
+  const codeOffset = varint.encodingLength(prefix.version)
+  const hashCodeOffset = codeOffset + varint.encodingLength(prefix.code)
+  const hashSizeOffset = hashCodeOffset + varint.encodingLength(prefix.multihash.code)
+  const bytes = new Uint8Array(hashSizeOffset + varint.encodingLength(prefix.multihash.size))
+  varint.encode(prefix.version, bytes, 0)
+  varint.encode(prefix.code, bytes, codeOffset)
+  varint.encode(prefix.multihash.code, bytes, hashCodeOffset)
+  varint.encode(prefix.multihash.size, bytes, hashSizeOffset)
+  return bytes
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {Prefix}
+ */
+export function decode (bytes) {
+  const version = varint.decode(bytes)
+  const codeOffset = varint.encodingLength(version)
+  const code = varint.decode(bytes, codeOffset)
+  const hashCodeOffset = codeOffset + varint.encodingLength(code)
+  const hashCode = varint.decode(bytes, hashCodeOffset)
+  const hashSizeOffset = hashCodeOffset + varint.encodingLength(hashCode)
+  const hashSize = varint.decode(bytes, hashSizeOffset)
+  return { version, code, multihash: { code: hashCode, size: hashSize } }
+}

--- a/prefix.test.js
+++ b/prefix.test.js
@@ -1,0 +1,15 @@
+import test from 'ava'
+import * as dagCbor from '@ipld/dag-cbor'
+import { sha256 } from 'multiformats/hashes/sha2'
+import * as Block from 'multiformats/block'
+import * as Prefix from './prefix.js'
+
+test('should round trip a prefix', async t => {
+  const { cid } = await Block.encode({ value: { some: 'data' }, codec: dagCbor, hasher: sha256 })
+  const bytes = Prefix.encode(cid)
+  const prefix = Prefix.decode(bytes)
+  t.is(prefix.version, cid.version)
+  t.is(prefix.code, cid.code)
+  t.is(prefix.multihash.code, cid.multihash.code)
+  t.is(prefix.multihash.size, cid.multihash.size)
+})

--- a/test.js
+++ b/test.js
@@ -43,8 +43,7 @@ test('should fetch a single CID', async t => {
   }
 })
 
-// FIXME: needs update to miniswap
-test.skip('should fetch blake2b hashed data', async t => {
+test('should fetch blake2b hashed data', async t => {
   // create blockstore and add data
   const serverBlockstore = new MemoryBlockstore()
   const data = fromString(`TEST DATA ${Date.now()}`)

--- a/test.js
+++ b/test.js
@@ -43,6 +43,7 @@ test('should fetch a single CID', async t => {
   }
 })
 
+// FIXME: needs update to miniswap
 test.skip('should fetch blake2b hashed data', async t => {
   // create blockstore and add data
   const serverBlockstore = new MemoryBlockstore()

--- a/test.js
+++ b/test.js
@@ -12,8 +12,7 @@ import { sha256 } from 'multiformats/hashes/sha2'
 import { CID } from 'multiformats/cid'
 import { Miniswap, BITSWAP_PROTOCOL } from 'miniswap'
 import { TimeoutController } from 'timeout-abort-controller'
-import { Dagula } from './index.js'
-import { getLibp2p } from './p2p.js'
+import { getLibp2p, fromNetwork } from './p2p.js'
 
 test('should fetch a single CID', async t => {
   // create blockstore and add data
@@ -36,7 +35,7 @@ test('should fetch a single CID', async t => {
   await server.start()
 
   const libp2p = await getLibp2p()
-  const dagula = await Dagula.fromNetwork(libp2p, { peer: server.getMultiaddrs()[0] })
+  const dagula = await fromNetwork(libp2p, { peer: server.getMultiaddrs()[0] })
   for await (const block of dagula.get(cid)) {
     t.is(block.cid.toString(), cid.toString())
     t.is(toString(block.bytes), toString(data))
@@ -69,7 +68,7 @@ test('should walk a unixfs path', async t => {
   await server.start()
 
   const libp2p = await getLibp2p()
-  const dagula = await Dagula.fromNetwork(libp2p, { peer: server.getMultiaddrs()[0] })
+  const dagula = await fromNetwork(libp2p, { peer: server.getMultiaddrs()[0] })
   const entries = []
   for await (const entry of dagula.walkUnixfsPath(`${dirCid}/${linkName}`)) {
     entries.push(entry)
@@ -92,7 +91,7 @@ test('should abort a fetch', async t => {
   await server.start()
 
   const libp2p = await getLibp2p()
-  const dagula = await Dagula.fromNetwork(libp2p, { peer: server.getMultiaddrs()[0] })
+  const dagula = await fromNetwork(libp2p, { peer: server.getMultiaddrs()[0] })
   // not in the blockstore so will hang indefinitely
   const cid = 'bafkreig7tekltu2k2bci74rpbyrruft4e7nrepzo4z36ie4n2bado5ru74'
   const controller = new TimeoutController(1_000)

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ import * as raw from 'multiformats/codecs/raw'
 import * as dagPB from '@ipld/dag-pb'
 import { UnixFS } from 'ipfs-unixfs'
 import { sha256 } from 'multiformats/hashes/sha2'
+import { blake2b256 } from '@multiformats/blake2/blake2b'
 import { CID } from 'multiformats/cid'
 import { Miniswap, BITSWAP_PROTOCOL } from 'miniswap'
 import { TimeoutController } from 'timeout-abort-controller'
@@ -36,6 +37,34 @@ test('should fetch a single CID', async t => {
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: server.getMultiaddrs()[0] })
+  for await (const block of dagula.get(cid)) {
+    t.is(block.cid.toString(), cid.toString())
+    t.is(toString(block.bytes), toString(data))
+  }
+})
+
+test.skip('should fetch blake2b hashed data', async t => {
+  // create blockstore and add data
+  const serverBlockstore = new MemoryBlockstore()
+  const data = fromString(`TEST DATA ${Date.now()}`)
+  const hash = await blake2b256.digest(data)
+  const cid = CID.create(1, raw.code, hash)
+  await serverBlockstore.put(cid, data)
+
+  const server = await createLibp2p({
+    addresses: { listen: ['/ip4/127.0.0.1/tcp/0/ws'] },
+    transports: [webSockets()],
+    streamMuxers: [mplex()],
+    connectionEncryption: [noise()]
+  })
+
+  const miniswap = new Miniswap(serverBlockstore)
+  server.handle(BITSWAP_PROTOCOL, miniswap.handler)
+
+  await server.start()
+
+  const libp2p = await getLibp2p()
+  const dagula = await fromNetwork(libp2p, { peer: server.getMultiaddrs()[0], hashers: { [blake2b256.code]: blake2b256 } })
   for await (const block of dagula.get(cid)) {
     t.is(block.cid.toString(), cid.toString())
     t.is(toString(block.bytes), toString(data))


### PR DESCRIPTION
This PR adds support for multiple hash types (like `blake2b`, as used by Filecoin).

To do this we make use of the "prefix" sent in bitswap wantlist responses. The prefix contains just the metadata of the CID. Instead of _assuming_ the multihash hasher is `sha256`, we now inspect the prefix and hash using the specified hasher (if it exists). By default, only `sha256` is supported (for smaller bundle), but in the CLI we also add `blake2b`.

Secondarily, this PR fixes a memory leak with many listeners being added to a passed abort controller which were never removed.

Thirdly, this PR moves the static `fromNetwork` factory function from the `Dagula` class into `p2p.js` (as an export). This allows users who are not using bitswap/libp2p (like freeway) to not end up with a massive bundle.