### PR TITLE
chore: release from ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.version }}
+          node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
       - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+on:
+  # run after the "build" workflow
+  workflow_run:
+    workflows: [build]
+    branches: [main]
+    types:
+      - completed
+
+name: Release
+jobs:
+  changelog:
+    # only run if tests succeed.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: rp
+        with:
+          release-type: node
+          package-name: dagula
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
+
+  publish:
+    # only publish if there is a change to the changelog
+    needs: changelog
+    if: ${{ needs.changelog.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dagula",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dagula",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dagula",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Suck a DAG out of a peer in the IPFS network.",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
- add release.yml to deploy dagula from CI on merge to main
- fix bug in build.yml that was not testing dagula on multiple node versions

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>