### PR TITLE
chore: fix ci publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
+          registry-url: 'https://registry.npmjs.org'
           node-version: 18
           cache: 'npm'
       - run: npm publish


### PR DESCRIPTION
Adds registry-url: 'https://registry.npmjs.org' to setup-node config to make publishing work.

with setup-node you *have* to set `registry-url: 'https://registry.npmjs.org'` as an option, or it won't write a .npmrc file which has the side effect of also setting up the node_auth_token!

License: MIT