### PR TITLE
fix: getPath through dag-cbor and identity nodes

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -3,6 +3,7 @@ import * as dagPb from '@ipld/dag-pb'
 import * as dagCbor from '@ipld/dag-cbor'
 import * as dagJson from '@ipld/dag-json'
 import { sha256 } from 'multiformats/hashes/sha2'
+import { identity } from 'multiformats/hashes/identity'
 
 /** @type {import('./index').BlockDecoders} */
 export const Decoders = {
@@ -14,5 +15,6 @@ export const Decoders = {
 
 /** @type {import('./index').MultihashHashers} */
 export const Hashers = {
+  [identity.code]: identity,
   [sha256.code]: sha256
 }

--- a/test/getPath.test.js
+++ b/test/getPath.test.js
@@ -46,20 +46,20 @@ test('should getPath', async t => {
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-  const entries = []
+  const blocks = []
   for await (const entry of dagula.getPath(`${dirNode.cid}/foo`)) {
-    entries.push(entry)
+    blocks.push(entry)
   }
   // did not try and return block for `other`
-  t.is(entries.length, 4)
-  t.deepEqual(entries.at(0).cid, dirNode.cid)
-  t.deepEqual(entries.at(0).bytes, dirNode.bytes)
-  t.deepEqual(entries.at(1).cid, fileNode.cid)
-  t.deepEqual(entries.at(1).bytes, fileNode.bytes)
-  t.deepEqual(entries.at(2).cid, filePart1.cid)
-  t.deepEqual(entries.at(2).bytes, filePart1.bytes)
-  t.deepEqual(entries.at(3).cid, filePart2.cid)
-  t.deepEqual(entries.at(3).bytes, filePart2.bytes)
+  t.is(blocks.length, 4)
+  t.deepEqual(blocks.at(0).cid, dirNode.cid)
+  t.deepEqual(blocks.at(0).bytes, dirNode.bytes)
+  t.deepEqual(blocks.at(1).cid, fileNode.cid)
+  t.deepEqual(blocks.at(1).bytes, fileNode.bytes)
+  t.deepEqual(blocks.at(2).cid, filePart1.cid)
+  t.deepEqual(blocks.at(2).bytes, filePart1.bytes)
+  t.deepEqual(blocks.at(3).cid, filePart2.cid)
+  t.deepEqual(blocks.at(3).bytes, filePart2.bytes)
 })
 
 test('should getPath through dag-cbor', async t => {
@@ -79,16 +79,16 @@ test('should getPath through dag-cbor', async t => {
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-  const entries = []
+  const blocks = []
   for await (const entry of dagula.getPath(`${cborRootNode.cid}/foo`)) {
-    entries.push(entry)
+    blocks.push(entry)
   }
   // did not try and return block for `other`
-  t.is(entries.length, 2)
-  t.deepEqual(entries.at(0).cid, cborRootNode.cid)
-  t.deepEqual(entries.at(0).bytes, cborRootNode.bytes)
-  t.deepEqual(entries.at(1).cid, fileNode.cid)
-  t.deepEqual(entries.at(1).bytes, fileNode.bytes)
+  t.is(blocks.length, 2)
+  t.deepEqual(blocks.at(0).cid, cborRootNode.cid)
+  t.deepEqual(blocks.at(0).bytes, cborRootNode.bytes)
+  t.deepEqual(blocks.at(1).cid, fileNode.cid)
+  t.deepEqual(blocks.at(1).bytes, fileNode.bytes)
 })
 
 // TODO: add dag-json to unixfs-exporter (Error: ipfs-unixfs-exporter walkPath: No resolver for code 297)
@@ -109,16 +109,16 @@ test.skip('should getPath through dag-json [unixfs-exporter missing dag-json cod
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-  const entries = []
+  const blocks = []
   for await (const entry of dagula.getPath(`${jsonRootNode.cid}/foo`)) {
-    entries.push(entry)
+    blocks.push(entry)
   }
   // did not try and return block for `other`
-  t.is(entries.length, 2)
-  t.deepEqual(entries.at(0).cid, jsonRootNode.cid)
-  t.deepEqual(entries.at(0).bytes, jsonRootNode.bytes)
-  t.deepEqual(entries.at(1).cid, fileNode.cid)
-  t.deepEqual(entries.at(1).bytes, fileNode.bytes)
+  t.is(blocks.length, 2)
+  t.deepEqual(blocks.at(0).cid, jsonRootNode.cid)
+  t.deepEqual(blocks.at(0).bytes, jsonRootNode.bytes)
+  t.deepEqual(blocks.at(1).cid, fileNode.cid)
+  t.deepEqual(blocks.at(1).bytes, fileNode.bytes)
 })
 
 test('should getPath through identity encoded dag-cbor', async t => {
@@ -138,16 +138,16 @@ test('should getPath through identity encoded dag-cbor', async t => {
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-  const entries = []
+  const blocks = []
   for await (const entry of dagula.getPath(`${identityCborRootNode.cid}/foo`)) {
-    entries.push(entry)
+    blocks.push(entry)
   }
   // did not try and return block for `other`
-  t.is(entries.length, 2)
-  t.deepEqual(entries.at(0).cid, identityCborRootNode.cid)
-  t.deepEqual(entries.at(0).bytes, identityCborRootNode.bytes)
-  t.deepEqual(entries.at(1).cid, fileNode.cid)
-  t.deepEqual(entries.at(1).bytes, fileNode.bytes)
+  t.is(blocks.length, 2)
+  t.deepEqual(blocks.at(0).cid, identityCborRootNode.cid)
+  t.deepEqual(blocks.at(0).bytes, identityCborRootNode.bytes)
+  t.deepEqual(blocks.at(1).cid, fileNode.cid)
+  t.deepEqual(blocks.at(1).bytes, fileNode.bytes)
 })
 
 test('should getPath on file with carScope=file', async t => {
@@ -183,21 +183,21 @@ test('should getPath on file with carScope=file', async t => {
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
 
-  const entries = []
+  const blocks = []
   const carScope = 'file'
   for await (const entry of dagula.getPath(`${dirNode.cid}/foo`, { carScope })) {
-    entries.push(entry)
+    blocks.push(entry)
   }
   // did not try and return block for `other`
-  t.is(entries.length, 4)
-  t.deepEqual(entries.at(0).cid, dirNode.cid)
-  t.deepEqual(entries.at(0).bytes, dirNode.bytes)
-  t.deepEqual(entries.at(1).cid, fileNode.cid)
-  t.deepEqual(entries.at(1).bytes, fileNode.bytes)
-  t.deepEqual(entries.at(2).cid, filePart1.cid)
-  t.deepEqual(entries.at(2).bytes, filePart1.bytes)
-  t.deepEqual(entries.at(3).cid, filePart2.cid)
-  t.deepEqual(entries.at(3).bytes, filePart2.bytes)
+  t.is(blocks.length, 4)
+  t.deepEqual(blocks.at(0).cid, dirNode.cid)
+  t.deepEqual(blocks.at(0).bytes, dirNode.bytes)
+  t.deepEqual(blocks.at(1).cid, fileNode.cid)
+  t.deepEqual(blocks.at(1).bytes, fileNode.bytes)
+  t.deepEqual(blocks.at(2).cid, filePart1.cid)
+  t.deepEqual(blocks.at(2).bytes, filePart1.bytes)
+  t.deepEqual(blocks.at(3).cid, filePart2.cid)
+  t.deepEqual(blocks.at(3).bytes, filePart2.bytes)
 })
 
 test('should getPath on file with carScope=block', async t => {
@@ -232,17 +232,17 @@ test('should getPath on file with carScope=block', async t => {
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-  const entries = []
+  const blocks = []
   const carScope = 'block'
   for await (const entry of dagula.getPath(`${dirNode.cid}/foo`, { carScope })) {
-    entries.push(entry)
+    blocks.push(entry)
   }
   // did not try and return block for `other`
-  t.is(entries.length, 2)
-  t.deepEqual(entries.at(0).cid, dirNode.cid)
-  t.deepEqual(entries.at(0).bytes, dirNode.bytes)
-  t.deepEqual(entries.at(1).cid, fileNode.cid)
-  t.deepEqual(entries.at(1).bytes, fileNode.bytes)
+  t.is(blocks.length, 2)
+  t.deepEqual(blocks.at(0).cid, dirNode.cid)
+  t.deepEqual(blocks.at(0).bytes, dirNode.bytes)
+  t.deepEqual(blocks.at(1).cid, fileNode.cid)
+  t.deepEqual(blocks.at(1).bytes, fileNode.bytes)
 })
 
 test('should getPath on dir with carScope=file', async t => {
@@ -265,14 +265,14 @@ test('should getPath on dir with carScope=file', async t => {
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-  const entries = []
+  const blocks = []
   for await (const entry of dagula.getPath(`${dirNode.cid}`, { carScope: 'file' })) {
-    entries.push(entry)
+    blocks.push(entry)
   }
   // only return the dir if carScope=file and target is a dir
-  t.is(entries.length, 1)
-  t.deepEqual(entries.at(0).cid, dirNode.cid)
-  t.deepEqual(entries.at(0).bytes, dirNode.bytes)
+  t.is(blocks.length, 1)
+  t.deepEqual(blocks.at(0).cid, dirNode.cid)
+  t.deepEqual(blocks.at(0).bytes, dirNode.bytes)
 })
 
 test('should getPath to a hamt dir with carScope=file', async t => {
@@ -286,26 +286,21 @@ test('should getPath to a hamt dir with carScope=file', async t => {
   const dir = UnixFS.createShardedDirectoryWriter({ writer })
   dir.set('foo', fileLink)
   const dirLink = await dir.close()
-
   writer.close()
 
-  const blocks = []
-  for await (const block of readable) {
-    blocks.push(block)
-  }
-
-  const peer = await startBitswapPeer(blocks)
+  const allBlocks = await collect(readable)
+  const peer = await startBitswapPeer(allBlocks)
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-  const entries = []
+  const blocks = []
   for await (const entry of dagula.getPath(`${dirLink.cid}`, { carScope: 'file' })) {
-    entries.push(entry)
+    blocks.push(entry)
   }
 
   // only return the dir if carScope=file and target is a dir
-  t.is(entries.length, 1)
-  t.deepEqual(entries.at(0).cid, dirLink.cid)
+  t.is(blocks.length, 1)
+  t.deepEqual(blocks.at(0).cid, dirLink.cid)
 })
 
 test('should getPath to a sharded hamt dir with carScope=file', async t => {
@@ -326,27 +321,22 @@ test('should getPath to a sharded hamt dir with carScope=file', async t => {
   }
   dir.set('foo', fileLink)
   const dirLink = await dir.close()
-
   writer.close()
 
-  const blocks = []
-  for await (const block of readable) {
-    blocks.push(block)
-  }
-
-  const peer = await startBitswapPeer(blocks)
+  const allBlocks = await collect(readable)
+  const peer = await startBitswapPeer(allBlocks)
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-  const res = []
+  const blocks = []
   for await (const block of dagula.getPath(`${dirLink.cid}`, { carScope: 'file' })) {
-    res.push(block)
+    blocks.push(block)
   }
 
   // return only the dir if carScope=file and target is a dir. file block should be missing
-  t.is(res.length, blocks.length - 1, 'all blocks for sharded dir were included')
-  t.deepEqual(res[0].cid, dirLink.cid, 'first block is root of dir')
-  t.false(res.some(b => b.cid.toString() === fileLink.cid.toString()), 'linked file was not returned because carScope: file')
+  t.is(blocks.length, allBlocks.length - 1, 'all blocks for sharded dir were included')
+  t.deepEqual(blocks[0].cid, dirLink.cid, 'first block is root of dir')
+  t.false(blocks.some(b => b.cid.toString() === fileLink.cid.toString()), 'linked file was not returned because carScope: file')
 })
 
 test('should getPath through sharded hamt dir with carScope=file', async t => {
@@ -367,26 +357,29 @@ test('should getPath through sharded hamt dir with carScope=file', async t => {
   }
   dir.set('foo', fileLink)
   const dirLink = await dir.close()
-
   writer.close()
 
-  const blocks = []
-  for await (const block of readable) {
-    blocks.push(block)
-  }
-
-  const peer = await startBitswapPeer(blocks)
+  const allBlocks = await collect(readable)
+  const peer = await startBitswapPeer(allBlocks)
 
   const libp2p = await getLibp2p()
   const dagula = await fromNetwork(libp2p, { peer: peer.libp2p.getMultiaddrs()[0] })
-
-  const res = []
+  const blocks = []
   for await (const block of dagula.getPath(`${dirLink.cid}/foo`, { carScope: 'file' })) {
-    res.push(block)
+    blocks.push(block)
   }
 
   // only return the hamt root, hamt shard, and file block
-  t.is(res.length, 3)
-  t.deepEqual(res.at(0).cid, dirLink.cid)
-  t.deepEqual(res.at(2).cid, fileLink.cid)
+  t.is(blocks.length, 3)
+  t.deepEqual(blocks.at(0).cid, dirLink.cid)
+  t.deepEqual(blocks.at(2).cid, fileLink.cid)
 })
+
+/** @param {AsyncIterable} source */
+async function collect (source) {
+  const blocks = []
+  for await (const block of source) {
+    blocks.push(block)
+  }
+  return blocks
+}


### PR DESCRIPTION
fix where getPath would error if traversing a dag-cbor node.
- getPath assumed a unixfs node with a .Links property when determining what links to follow.
- It now uses the unixfs entry.type to deal with dag-cbor nodes.
- NOTE: dag-json is not currently supported as unixfs-exporter doesn't support it!

 add support for identity encoded CIDs
 - deal with them where we are looking for links from getPath
 - special case them before asking the blockstore so we dont need every blockstore impl to special case them.

License: MIT