### PR TITLE
Add ordering option to getPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,9 +81,7 @@ export class Dagula {
         yield block
         const blockCids = search(block)
         if (order === 'dfs') {
-          for await (const block of this.get(blockCids, options)) {
-            yield block
-          }
+          yield * this.get(blockCids, options)
         } else {
           nextCids = nextCids.concat(blockCids)
         }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import { CID } from 'multiformats/cid'
 import * as dagPB from '@ipld/dag-pb'
 import * as Block from 'multiformats/block'
 import { exporter, walkPath } from 'ipfs-unixfs-exporter'
-import { transform } from 'streaming-iterables'
+import { parallelMap, transform } from 'streaming-iterables'
 import { Decoders, Hashers } from './defaults.js'
 import { identity } from 'multiformats/hashes/identity'
 
@@ -50,7 +50,8 @@ export class Dagula {
 
     while (cids.length > 0) {
       log('fetching %d CIDs', cids.length)
-      const fetchBlocks = transform(cids.length, async cid => {
+      const parallelFn = order === 'dfs' ? parallelMap : transform
+      const fetchBlocks = parallelFn(cids.length, async cid => {
         if (signal) {
           const aborter = new AbortController()
           aborters.push(aborter)

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ export class Dagula {
    * @param {string} cidPath
    * @param {object} [options]
    * @param {AbortSignal} [options.signal]
-   * @param {'dfs','rnd'} [options.order]
+   * @param {'dfs'|'unk'} [options.order] Specify desired block ordering. `dfs` - Depth First Search, `unk` - unknown ordering.
    * @param {'all'|'file'|'block'} [options.carScope] control how many layers of the dag are returned
    *    'all': return the entire dag starting at path. (default)
    *    'block': return the block identified by the path.


### PR DESCRIPTION
# Goals

This adds support for depth first traversals to Dagula. It's designed to be in conformance with https://github.com/ipfs/specs/pull/412.

(will update if parameter names change)

# Implementation

- adds order parameter to options struct for getPath and get
- renames breadFirstSearch to blockLinks (it isn't really "bread first search" so much as "all the links in this block").
- handles ordering change inside of `get`, using recursion for depth-first-search
- adds tests for both orders.
