### PR TITLE
refactor: change block ordering default

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -62,8 +62,10 @@ cli.command('block get <cid>')
 cli.command('get <cid>')
   .describe('Fetch a DAG from the peer. Outputs a CAR file.')
   .option('-p, --peer', 'Address of peer to fetch data from.')
+  .option('-r, --order', 'Specify returned order of blocks in the DAG, "dfs" or "unk"', 'dfs')
+  .option('-s, --dag-scope', 'Specify the set of blocks of the targeted DAG to get, "all", "entity" or "block"', 'all')
   .option('-t, --timeout', 'Timeout in milliseconds.', TIMEOUT)
-  .action(async (cidPath, { peer, timeout }) => {
+  .action(async (cidPath, { peer, order, ['dag-scope']: dagScope, timeout }) => {
     const [cidStr] = cidPath.replace(/^\/ipfs\//, '').split('/')
     const cid = CID.parse(cidStr)
     const controller = new TimeoutController(timeout)
@@ -74,7 +76,7 @@ cli.command('get <cid>')
       let error
       ;(async () => {
         try {
-          for await (const block of dagula.getPath(cidPath, { signal: controller.signal })) {
+          for await (const block of dagula.getPath(cidPath, { signal: controller.signal, order, dagScope })) {
             controller.reset()
             await writer.put(block)
           }

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,15 +62,39 @@ export interface DagScopeOptions {
   dagScope?: DagScope
 }
 
+/**
+ * [Depth-First Search](https://en.wikipedia.org/wiki/Depth-first_search)
+ * order, enables streaming responses with minimal memory usage.
+ */
+export type BlockOrderDepthFirstSearch = 'dfs'
+
+/**
+ * Unknown order. In this case, the client cannot make any assumptions about
+ * the block order: blocks may arrive in a random order or be a result of a
+ * custom DAG traversal algorithm.
+ */
+export type BlockOrderUnknown = 'unk'
+
+/** Block ordering algorithms. */
+export type BlockOrder = BlockOrderDepthFirstSearch | BlockOrderUnknown
+
+export interface BlockOrderOptions {
+  /**
+   * Specify returned order of blocks in the DAG.
+   * Default: `BlockOrderDepthFirstSearch`.
+   */
+  order?: BlockOrder
+}
+
 export interface IDagula {
   /**
-   * Get a complete DAG.
+   * Get a complete DAG by root CID.
    */
-  get (cid: CID|string, options?: AbortOptions): AsyncIterableIterator<Block>
+  get (cid: CID|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /**
    * Get a DAG for a cid+path.
    */
-  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions): AsyncIterableIterator<Block>
+  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /**
    * Get a single block.
    */
@@ -88,13 +112,13 @@ export interface IDagula {
 export declare class Dagula implements IDagula {
   constructor (blockstore: Blockstore, options?: { decoders?: BlockDecoders, hashers?: MultihashHashers })
   /**
-   * Get a complete DAG.
+   * Get a complete DAG by root CID.
    */
-  get (cid: CID|string, options?: AbortOptions): AsyncIterableIterator<Block>
+  get (cid: CID|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /**
    * Get a DAG for a cid+path.
    */
-  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions): AsyncIterableIterator<Block>
+  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /**
    * Get a single block.
    */

--- a/index.js
+++ b/index.js
@@ -34,11 +34,12 @@ export class Dagula {
    * @param {CID[]|CID|string} cid
    * @param {object} [options]
    * @param {AbortSignal} [options.signal]
+   * @param {import('./index').BlockOrder} [options.order]
    * @param {(block: import('multiformats').BlockView) => CID[]} [options.search]
    */
   async * get (cid, options = {}) {
     cid = typeof cid === 'string' ? CID.parse(cid) : cid
-    const order = options.order ?? 'rnd'
+    const order = options.order ?? 'dfs'
     log('getting DAG %s', cid)
     let cids = Array.isArray(cid) ? cid : [cid]
     const search = options.search || blockLinks()
@@ -101,7 +102,7 @@ export class Dagula {
    * @param {string} cidPath
    * @param {object} [options]
    * @param {AbortSignal} [options.signal]
-   * @param {'dfs'|'unk'} [options.order] Specify desired block ordering. `dfs` - Depth First Search, `unk` - unknown ordering.
+   * @param {import('./index').BlockOrder} [options.order] Specify desired block ordering. `dfs` - Depth First Search, `unk` - unknown ordering.
    * @param {import('./index').DagScope} [options.dagScope] control how many layers of the dag are returned
    *    'all': return the entire dag starting at path. (default)
    *    'block': return the block identified by the path.

--- a/test/getPath.test.js
+++ b/test/getPath.test.js
@@ -200,7 +200,7 @@ test('should getPath on file with dagScope=entity', async t => {
   t.deepEqual(blocks.at(3).bytes, filePart2.bytes)
 })
 
-test('should getPath on large file with dagScope=entity, default ordering', async t => {
+test('should getPath on large file with dagScope=entity, order=unk', async t => {
   // return all blocks in path and all blocks for resolved target of path
   const filePart1 = await Block.decode({ codec: raw, bytes: fromString(`MORE TEST DATA ${Date.now()}`), hasher: sha256 })
   const filePart2 = await Block.decode({ codec: raw, bytes: fromString(`EVEN MORE TEST DATA ${Date.now()}`), hasher: sha256 })
@@ -260,7 +260,8 @@ test('should getPath on large file with dagScope=entity, default ordering', asyn
 
   const blocks = []
   const dagScope = 'entity'
-  for await (const entry of dagula.getPath(`${dirNode.cid}/foo`, { dagScope })) {
+  const order = 'unk'
+  for await (const entry of dagula.getPath(`${dirNode.cid}/foo`, { dagScope, order })) {
     blocks.push(entry)
   }
   // did not try and return block for `other`
@@ -283,7 +284,7 @@ test('should getPath on large file with dagScope=entity, default ordering', asyn
   t.deepEqual(blocks.at(7).bytes, filePart4.bytes)
 })
 
-test('should getPath on large file with dagScope=entity, dfs ordering', async t => {
+test('should getPath on large file with dagScope=entity, order=dfs', async t => {
   // return all blocks in path and all blocks for resolved target of path
   const filePart1 = await Block.decode({ codec: raw, bytes: fromString(`MORE TEST DATA ${Date.now()}`), hasher: sha256 })
   const filePart2 = await Block.decode({ codec: raw, bytes: fromString(`EVEN MORE TEST DATA ${Date.now()}`), hasher: sha256 })
@@ -343,7 +344,8 @@ test('should getPath on large file with dagScope=entity, dfs ordering', async t 
 
   const blocks = []
   const dagScope = 'entity'
-  for await (const entry of dagula.getPath(`${dirNode.cid}/foo`, { dagScope, order: 'dfs' })) {
+  const order = 'dfs'
+  for await (const entry of dagula.getPath(`${dirNode.cid}/foo`, { dagScope, order })) {
     blocks.push(entry)
   }
   // did not try and return block for `other`
@@ -365,6 +367,7 @@ test('should getPath on large file with dagScope=entity, dfs ordering', async t 
   t.deepEqual(blocks.at(7).cid, filePart4.cid)
   t.deepEqual(blocks.at(7).bytes, filePart4.bytes)
 })
+
 test('should getPath on file with dagScope=block', async t => {
   // return all blocks in path and all blocks for resolved target of path
   const filePart1 = await Block.decode({ codec: raw, bytes: fromString(`MORE TEST DATA ${Date.now()}`), hasher: sha256 })
@@ -410,7 +413,7 @@ test('should getPath on file with dagScope=block', async t => {
   t.deepEqual(blocks.at(1).bytes, fileNode.bytes)
 })
 
-test('should getPath on dir with dagScope=file', async t => {
+test('should getPath on dir with dagScope=entity', async t => {
   // return all blocks in path. as it's a dir, it should stop there
   const file = await Block.decode({ codec: raw, bytes: fromString(`MORE TEST DATA ${Date.now()}`), hasher: sha256 })
 


### PR DESCRIPTION
Switch block ordering to depth first by default. When specifying `unk` you get the (dag) house ordering.