### PR TITLE
refactor!: remove search option

### DIFF
--- a/bitswap-fetcher.js
+++ b/bitswap-fetcher.js
@@ -16,9 +16,9 @@ const log = debug('dagula:bitswapfetcher')
 export class BitswapFetcher {
   /** @type {() => Promise<import('@libp2p/interface-connection').Stream>} */
   #newStream
-  /** @type {Map<string, Array<{ cid: import('multiformats').CID, deferredPromise: import('p-defer').DeferredPromise<Block|undefined> }>>} */
+  /** @type {Map<string, Array<{ cid: import('multiformats').UnknownLink, deferredPromise: import('p-defer').DeferredPromise<Block|undefined> }>>} */
   #wants = new Map()
-  /** @type {import('multiformats').CID[]} */
+  /** @type {import('multiformats').UnknownLink[]} */
   #wantlist = []
   /** @type {number} */
   #outstandingWants = 0
@@ -83,7 +83,7 @@ export class BitswapFetcher {
   }
 
   /**
-   * @param {import('multiformats').CID} cid
+   * @param {import('multiformats').UnknownLink} cid
    * @param {{ signal?: AbortSignal }} [options]
    */
   get (cid, options = {}) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import type { BlockDecoder } from 'multiformats/codecs/interface'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
-import type { CID } from 'multiformats'
+import type { UnknownLink } from 'multiformats'
 import type { UnixFSEntry } from 'ipfs-unixfs-exporter'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { AbortOptions } from '@libp2p/interfaces'
@@ -17,12 +17,12 @@ export interface MultihashHashers {
 }
 
 export interface Block {
-  cid: CID
+  cid: UnknownLink
   bytes: Uint8Array
 }
 
 export interface Blockstore {
-  get: (cid: CID, options?: { signal?: AbortSignal }) => Promise<Block | undefined>
+  get: (cid: UnknownLink, options?: { signal?: AbortSignal }) => Promise<Block | undefined>
 }
 
 export interface Network {
@@ -90,7 +90,7 @@ export interface IDagula {
   /**
    * Get a complete DAG by root CID.
    */
-  get (cid: CID|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
+  get (cid: UnknownLink|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /**
    * Get a DAG for a cid+path.
    */
@@ -98,15 +98,15 @@ export interface IDagula {
   /**
    * Get a single block.
    */
-  getBlock (cid: CID|string, options?: AbortOptions): Promise<Block>
+  getBlock (cid: UnknownLink|string, options?: AbortOptions): Promise<Block>
   /**
    * Get UnixFS files and directories.
    */
-  getUnixfs (path: CID|string, options?: AbortOptions): Promise<UnixFSEntry>
+  getUnixfs (path: UnknownLink|string, options?: AbortOptions): Promise<UnixFSEntry>
   /**
    * Emit nodes for all path segements and get UnixFS files and directories.
    */
-  walkUnixfsPath (path: CID|string, options?: AbortOptions): AsyncIterableIterator<UnixFSEntry>
+  walkUnixfsPath (path: UnknownLink|string, options?: AbortOptions): AsyncIterableIterator<UnixFSEntry>
 }
 
 export declare class Dagula implements IDagula {
@@ -114,7 +114,7 @@ export declare class Dagula implements IDagula {
   /**
    * Get a complete DAG by root CID.
    */
-  get (cid: CID|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
+  get (cid: UnknownLink|string, options?: AbortOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /**
    * Get a DAG for a cid+path.
    */
@@ -122,13 +122,13 @@ export declare class Dagula implements IDagula {
   /**
    * Get a single block.
    */
-  getBlock (cid: CID|string, options?: AbortOptions): Promise<Block>
+  getBlock (cid: UnknownLink|string, options?: AbortOptions): Promise<Block>
   /**
    * Get UnixFS files and directories.
    */
-  getUnixfs (path: CID|string, options?: AbortOptions): Promise<UnixFSEntry>
+  getUnixfs (path: UnknownLink|string, options?: AbortOptions): Promise<UnixFSEntry>
   /**
    * Emit nodes for all path segements and get UnixFS files and directories.
    */
-  walkUnixfsPath (path: CID|string, options?: AbortOptions): AsyncIterableIterator<UnixFSEntry>
+  walkUnixfsPath (path: UnknownLink|string, options?: AbortOptions): AsyncIterableIterator<UnixFSEntry>
 }

--- a/message.js
+++ b/message.js
@@ -36,7 +36,7 @@ const ADDED_ESTIMATION_PERCENTAGE = 0.1
 
 export class Entry {
   /**
-   * @param {CID} cid
+   * @param {import('multiformats').UnknownLink} cid
    * @param {Object} [options]
    * @param {number} [options.priority]
    * @param {boolean} [options.cancel]
@@ -125,15 +125,13 @@ export class Wantlist {
 
 export class Block {
   /**
-   * @param {Uint8Array|CID} prefixOrCid
+   * @param {Uint8Array|import('multiformats').UnknownLink} prefixOrCid
    * @param {Uint8Array} data
    */
   constructor (prefixOrCid, data) {
-    if (prefixOrCid instanceof CID) {
-      prefixOrCid = Prefix.encode(prefixOrCid)
-    }
-
-    this.prefix = prefixOrCid
+    this.prefix = prefixOrCid instanceof Uint8Array
+      ? prefixOrCid
+      : Prefix.encode(prefixOrCid)
     this.data = data
   }
 
@@ -155,7 +153,7 @@ export class Block {
 
 export class BlockPresence {
   /**
-   * @param {CID} cid
+   * @param {import('multiformats').UnknownLink} cid
    * @param {gen.Message.BlockPresenceType} type
    */
   constructor (cid, type) {


### PR DESCRIPTION
This PR removes the internal `search` option in favour of a block `filter` option.

I also fixed all the types in `index.js`...was having a hard time with `Link` vs `CID` and decided to upgrade everything to use `Link`, seeing as this is going out as a breaking change anyway.