### PR TITLE
fix: depth-first order must apply to array of links passed to `get`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "dagula",
-      "version": "6.0.2",
+      "version": "7.0.0",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^11.0.0",


### PR DESCRIPTION
`getPath` provides all the links from a previously resolved block to `get`. `get` must apply the depth first ordering logic to the links passed in, otherwise we do an initial breadth-first pass, then depth-first after that.

pull depth-first search logic out to it's own function and use a queue rather than recursion to manage the backlog of links.

fixes: https://github.com/web3-storage/freeway/issues/42

License: MIT