### PR TITLE
feat: implement entity bytes option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,30 @@ export interface DagScopeOptions {
 }
 
 /**
+ * Specifies a range of bytes.
+ * - `*` can be substituted for end-of-file
+ *     - `{ from: 0, to: '*' }` is the entire file.
+ * - Negative numbers can be used for referring to bytes from the end of a file
+ *     - `{ from: -1024, to: '*' }` is the last 1024 bytes of a file.
+ * - It is also permissible to ask for the range of 500 bytes from the
+ * beginning of the file to 1000 bytes from the end: `{ from: 499, to: -1000 }`
+ */
+export interface ByteRange {
+  /** Byte-offset of the first byte in a range (inclusive) */
+  from: number
+  /** Byte-offset of the last byte in the range (inclusive) */
+  to: number|'*'
+}
+
+export interface EntityBytesOptions {
+  /**
+   * A specific byte range from the entity. Setting entity bytes implies DAG
+   * scope: entity.
+   */
+  entityBytes?: ByteRange
+}
+
+/**
  * [Depth-First Search](https://en.wikipedia.org/wiki/Depth-first_search)
  * order, enables streaming responses with minimal memory usage.
  */
@@ -94,7 +118,7 @@ export interface IDagula {
   /**
    * Get a DAG for a cid+path.
    */
-  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & BlockOrderOptions): AsyncIterableIterator<Block>
+  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & EntityBytesOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /**
    * Get a single block.
    */
@@ -118,7 +142,7 @@ export declare class Dagula implements IDagula {
   /**
    * Get a DAG for a cid+path.
    */
-  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & BlockOrderOptions): AsyncIterableIterator<Block>
+  getPath (cidPath: string, options?: AbortOptions & DagScopeOptions & EntityBytesOptions & BlockOrderOptions): AsyncIterableIterator<Block>
   /**
    * Get a single block.
    */

--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ export class Dagula {
       // the single block for the root has already been yielded.
       // For a hamt we must fetch all the blocks of the (current) hamt.
       if (base.unixfs.type === 'hamt-sharded-directory') {
-        const padLength = getHamtPadLength(base.unixfs.fanout)
+        const padLength = getUnixfsHamtPadLength(base.unixfs.fanout)
         const hamtLinks = base.node.Links?.filter(l => l.Name?.length === padLength).map(l => l.Hash) || []
         if (hamtLinks.length) {
           yield * this.get(hamtLinks, { filter: hamtFilter, signal: options.signal, order: options.order })
@@ -271,15 +271,6 @@ export class Dagula {
   }
 }
 
-/** @param {number|bigint|undefined} fanout */
-function getHamtPadLength (fanout) {
-  // TODO: remove when https://github.com/ipfs/js-ipfs-unixfs/pull/355 lands
-  // (Current ipfs-unixfs does not unmarshal fanout)
-  fanout = fanout ?? Math.pow(2, 8)
-  if (!fanout) throw new Error('missing fanout')
-  return (Number(fanout) - 1).toString(16).length
-}
-
 /**
  * Create a search function that given a decoded Block and selector, will
  * return an array of `GraphSelector` of things to fetch next.
@@ -334,7 +325,7 @@ export function blockLinks (linkFilter = () => true) {
 const isDagPB = block => block.cid.code === dagPB.code
 
 /** @type {LinkFilter} */
-export const hamtFilter = ([name], data) => data ? name?.length === getHamtPadLength(data.fanout) : false
+export const hamtFilter = ([name], data) => data ? name?.length === getUnixfsHamtPadLength(data.fanout) : false
 
 /**
  * Converts an array of block sizes to an array of byte ranges.
@@ -434,6 +425,15 @@ function getUnixfsEntryLinkSelectors (entry, decoders, range) {
 
   // raw! no links!
   return []
+}
+
+/** @param {number|bigint|undefined} fanout */
+function getUnixfsHamtPadLength (fanout) {
+  // TODO: remove when https://github.com/ipfs/js-ipfs-unixfs/pull/355 lands
+  // (Current ipfs-unixfs does not unmarshal fanout)
+  fanout = fanout ?? Math.pow(2, 8)
+  if (!fanout) throw new Error('missing fanout')
+  return (Number(fanout) - 1).toString(16).length
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -273,6 +273,9 @@ export class Dagula {
 
 /** @param {number|bigint|undefined} fanout */
 function getHamtPadLength (fanout) {
+  // TODO: remove when https://github.com/ipfs/js-ipfs-unixfs/pull/355 lands
+  // (Current ipfs-unixfs does not unmarshal fanout)
+  fanout = fanout ?? Math.pow(2, 8)
   if (!fanout) throw new Error('missing fanout')
   return (Number(fanout) - 1).toString(16).length
 }

--- a/index.js
+++ b/index.js
@@ -274,8 +274,8 @@ export class Dagula {
 }
 
 /**
- * Create a search function that given a decoded Block and selector.
- * will return an array of GraphSelector to fetch next.
+ * Create a search function that given a decoded Block and selector, will
+ * return an array of `GraphSelector` of things to fetch next.
  *
  * @param {LinkFilter} linkFilter
  */

--- a/index.js
+++ b/index.js
@@ -188,17 +188,14 @@ export class Dagula {
         // resolve entity bytes to actual byte offsets
         range = [
           entityBytes.from < 0
-            ? Math.max(0, size + entityBytes.from)
+            ? size - 1 + entityBytes.from
             : entityBytes.from,
           entityBytes.to === '*'
             ? size - 1
             : entityBytes.to < 0
-              ? Math.max(0, size + entityBytes.to)
+              ? size - 1 + entityBytes.to
               : entityBytes.to
         ]
-        if (range[0] > range[1]) {
-          throw new Error(`invalid range: ${range[0]}-${range[1]}`)
-        }
       }
       const selectors = getUnixfsEntryLinkSelectors(base, this.#decoders, range)
       yield * this.#get(selectors, { signal: options.signal, order: options.order })

--- a/index.js
+++ b/index.js
@@ -188,12 +188,12 @@ export class Dagula {
         // resolve entity bytes to actual byte offsets
         range = [
           entityBytes.from < 0
-            ? Math.max(0, size - entityBytes.from)
+            ? Math.max(0, size + entityBytes.from)
             : entityBytes.from,
           entityBytes.to === '*'
             ? size - 1
             : entityBytes.to < 0
-              ? Math.max(0, size - entityBytes.to)
+              ? Math.max(0, size + entityBytes.to)
               : entityBytes.to
         ]
         if (range[0] > range[1]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.0",
         "@ipld/dag-pb": "^4.0.0",
-        "@ipld/specs": "^1.0.1",
         "@libp2p/interface-connection": "^3.0.8",
         "@libp2p/interface-peer-id": "^2.0.1",
         "@libp2p/interface-registrar": "^2.0.8",
@@ -44,6 +43,7 @@
         "dagula": "bin.js"
       },
       "devDependencies": {
+        "@ipld/specs": "^1.0.2",
         "@ipld/unixfs": "^2.1.1",
         "ava": "^5.2.0",
         "blockstore-core": "^1.0.5",
@@ -518,9 +518,10 @@
       }
     },
     "node_modules/@ipld/specs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@ipld/specs/-/specs-1.0.1.tgz",
-      "integrity": "sha512-zCvxsBwsHqMWWJQnyDL6QgOOlb4wusNvOhi3+Ci3mzyp3vfluGjA1Z8wKmyuBL+TH3KA3Ni03PJJShNvM5C8KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/specs/-/specs-1.0.2.tgz",
+      "integrity": "sha512-+wI6M8o1w5si6KjPAJNLdd9MVIZ0VDIa6uYVNmD4CJ/MLJN55dM0d0X7HtZl4WqKDFoQPQRW8A2pIjCiz0/I5A==",
+      "dev": true,
       "dependencies": {
         "multiformats": "^12.0.1",
         "testmark.js": "^1.0.6"
@@ -530,6 +531,7 @@
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
       "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -8115,7 +8117,8 @@
     "node_modules/testmark.js": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/testmark.js/-/testmark.js-1.0.6.tgz",
-      "integrity": "sha512-0cJjEYcOT+OpIx+no76ri255M4YQvfWy8yQr5vcG+9tqEvvrb3zWIVFifQSdfMrkHvGeRFwKtM47CXUMH9jakA=="
+      "integrity": "sha512-0cJjEYcOT+OpIx+no76ri255M4YQvfWy8yQr5vcG+9tqEvvrb3zWIVFifQSdfMrkHvGeRFwKtM47CXUMH9jakA==",
+      "dev": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.0",
         "@ipld/dag-pb": "^4.0.0",
+        "@ipld/specs": "^1.0.1",
         "@libp2p/interface-connection": "^3.0.8",
         "@libp2p/interface-peer-id": "^2.0.1",
         "@libp2p/interface-registrar": "^2.0.8",
@@ -50,8 +51,7 @@
         "ipfs-unixfs": "^11.0.1",
         "lnmap": "^1.0.1",
         "miniswap": "^2.0.2",
-        "standard": "^17.0.0",
-        "testmark.js": "^1.0.6"
+        "standard": "^17.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -509,6 +509,24 @@
       }
     },
     "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/specs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/specs/-/specs-1.0.1.tgz",
+      "integrity": "sha512-zCvxsBwsHqMWWJQnyDL6QgOOlb4wusNvOhi3+Ci3mzyp3vfluGjA1Z8wKmyuBL+TH3KA3Ni03PJJShNvM5C8KQ==",
+      "dependencies": {
+        "multiformats": "^12.0.1",
+        "testmark.js": "^1.0.6"
+      }
+    },
+    "node_modules/@ipld/specs/node_modules/multiformats": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
       "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
@@ -8097,8 +8115,7 @@
     "node_modules/testmark.js": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/testmark.js/-/testmark.js-1.0.6.tgz",
-      "integrity": "sha512-0cJjEYcOT+OpIx+no76ri255M4YQvfWy8yQr5vcG+9tqEvvrb3zWIVFifQSdfMrkHvGeRFwKtM47CXUMH9jakA==",
-      "dev": true
+      "integrity": "sha512-0cJjEYcOT+OpIx+no76ri255M4YQvfWy8yQr5vcG+9tqEvvrb3zWIVFifQSdfMrkHvGeRFwKtM47CXUMH9jakA=="
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,11 @@
         "@ipld/unixfs": "^2.1.1",
         "ava": "^5.2.0",
         "blockstore-core": "^1.0.5",
-        "ipfs-unixfs": "^11.0.0",
-        "miniswap": "^2.0.1",
-        "standard": "^17.0.0"
+        "carstream": "^1.1.0",
+        "ipfs-unixfs": "^11.0.1",
+        "miniswap": "^2.0.2",
+        "standard": "^17.0.0",
+        "testmark.js": "^1.0.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2995,6 +2997,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/carstream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/carstream/-/carstream-1.1.0.tgz",
+      "integrity": "sha512-tbf8FOnGX1+0kOe77nm9MG53REiqQopDwzwbXYVxUcsKOAHG2KSD++qy95v1vrtRt1Q6L0Sb01it7QwJ+Yt1sQ==",
+      "dev": true,
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.3",
+        "multiformats": "^12.0.1",
+        "uint8arraylist": "^2.4.3"
+      }
+    },
+    "node_modules/carstream/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/cbor": {
@@ -6445,9 +6468,9 @@
       }
     },
     "node_modules/miniswap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/miniswap/-/miniswap-2.0.1.tgz",
-      "integrity": "sha512-2aZSXftF2v6iK99NWWwZWWGeY/30rZqFZslzI2wYWVXpZq67xWUjO8YQeWsNPvV9tohbxwsNmsib3G9mMcRi6A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/miniswap/-/miniswap-2.0.2.tgz",
+      "integrity": "sha512-3GGSCIYzrFWC9ZBoBiloIwFVFm75LXMuKcuprmojJxJwapd69dzKXns6B4IwfmC/772FkAXyy5otsxJNYe6dlw==",
       "dev": true,
       "dependencies": {
         "@libp2p/interface-registrar": "^2.0.8",
@@ -8050,6 +8073,12 @@
       "engines": {
         "node": ">=14.16"
       }
+    },
+    "node_modules/testmark.js": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/testmark.js/-/testmark.js-1.0.6.tgz",
+      "integrity": "sha512-0cJjEYcOT+OpIx+no76ri255M4YQvfWy8yQr5vcG+9tqEvvrb3zWIVFifQSdfMrkHvGeRFwKtM47CXUMH9jakA==",
+      "dev": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "archy": "^1.0.0",
         "conf": "^11.0.1",
         "debug": "^4.3.4",
+        "ipfs-unixfs": "^11.0.2",
         "ipfs-unixfs-exporter": "^13.1.6",
         "it-length-prefixed": "^8.0.4",
         "it-pipe": "^2.0.3",
@@ -48,7 +49,6 @@
         "ava": "^5.2.0",
         "blockstore-core": "^1.0.5",
         "carstream": "^1.1.0",
-        "ipfs-unixfs": "^11.0.1",
         "lnmap": "^1.0.1",
         "miniswap": "^2.0.2",
         "standard": "^17.0.0"
@@ -5093,9 +5093,9 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.1.tgz",
-      "integrity": "sha512-SD9dqn14bfgMfkPstsR/2Av3zCzYMj2ntQJab4HZucgX4nNV6K7guZh4Hf3kiL8ONff1Ogft1ekFU083DIKEdQ==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.2.tgz",
+      "integrity": "sha512-KaAUs5VVJmW0P0EV/XbEwxRXdhwdRiIA77hrmCzVjSKKsBdt5jt+623IvFNioAMqaoN0OcxN0pOCdA3hKSgYUw==",
       "dependencies": {
         "err-code": "^3.0.1",
         "protons-runtime": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "blockstore-core": "^1.0.5",
         "carstream": "^1.1.0",
         "ipfs-unixfs": "^11.0.1",
+        "lnmap": "^1.0.1",
         "miniswap": "^2.0.2",
         "standard": "^17.0.0",
         "testmark.js": "^1.0.6"
@@ -6252,6 +6253,25 @@
       },
       "peerDependencies": {
         "uint8arraylist": "^2.3.2"
+      }
+    },
+    "node_modules/lnmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lnmap/-/lnmap-1.0.1.tgz",
+      "integrity": "sha512-AmgSSYqvPHWCqMpJAZGRdkY82FXBRHwSVVf25uGCqge7xO4oabef7E4XzNUzverVhL5YobnjkgzgvidfXbfMBA==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/lnmap/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/load-json-file": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "archy": "^1.0.0",
     "conf": "^11.0.1",
     "debug": "^4.3.4",
+    "ipfs-unixfs": "^11.0.2",
     "ipfs-unixfs-exporter": "^13.1.6",
     "it-length-prefixed": "^8.0.4",
     "it-pipe": "^2.0.3",
@@ -53,7 +54,6 @@
     "ava": "^5.2.0",
     "blockstore-core": "^1.0.5",
     "carstream": "^1.1.0",
-    "ipfs-unixfs": "^11.0.1",
     "lnmap": "^1.0.1",
     "miniswap": "^2.0.2",
     "standard": "^17.0.0"

--- a/package.json
+++ b/package.json
@@ -51,9 +51,11 @@
     "@ipld/unixfs": "^2.1.1",
     "ava": "^5.2.0",
     "blockstore-core": "^1.0.5",
-    "ipfs-unixfs": "^11.0.0",
-    "miniswap": "^2.0.1",
-    "standard": "^17.0.0"
+    "carstream": "^1.1.0",
+    "ipfs-unixfs": "^11.0.1",
+    "miniswap": "^2.0.2",
+    "standard": "^17.0.0",
+    "testmark.js": "^1.0.6"
   },
   "types": "./index.d.ts",
   "repository": {
@@ -71,5 +73,10 @@
   "bugs": {
     "url": "https://github.com/web3-storage/dagula/issues"
   },
-  "homepage": "https://github.com/web3-storage/dagula#readme"
+  "homepage": "https://github.com/web3-storage/dagula#readme",
+  "standard": {
+    "ignore": [
+      "*.ts"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@ipld/dag-cbor": "^9.0.0",
     "@ipld/dag-json": "^10.0.0",
     "@ipld/dag-pb": "^4.0.0",
+    "@ipld/specs": "^1.0.1",
     "@libp2p/interface-connection": "^3.0.8",
     "@libp2p/interface-peer-id": "^2.0.1",
     "@libp2p/interface-registrar": "^2.0.8",
@@ -55,8 +56,7 @@
     "ipfs-unixfs": "^11.0.1",
     "lnmap": "^1.0.1",
     "miniswap": "^2.0.2",
-    "standard": "^17.0.0",
-    "testmark.js": "^1.0.6"
+    "standard": "^17.0.0"
   },
   "types": "./index.d.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "blockstore-core": "^1.0.5",
     "carstream": "^1.1.0",
     "ipfs-unixfs": "^11.0.1",
+    "lnmap": "^1.0.1",
     "miniswap": "^2.0.2",
     "standard": "^17.0.0",
     "testmark.js": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@ipld/dag-cbor": "^9.0.0",
     "@ipld/dag-json": "^10.0.0",
     "@ipld/dag-pb": "^4.0.0",
-    "@ipld/specs": "^1.0.1",
     "@libp2p/interface-connection": "^3.0.8",
     "@libp2p/interface-peer-id": "^2.0.1",
     "@libp2p/interface-registrar": "^2.0.8",
@@ -49,6 +48,7 @@
     "varint": "^6.0.0"
   },
   "devDependencies": {
+    "@ipld/specs": "^1.0.2",
     "@ipld/unixfs": "^2.1.1",
     "ava": "^5.2.0",
     "blockstore-core": "^1.0.5",

--- a/test/helpers/blockstore.js
+++ b/test/helpers/blockstore.js
@@ -1,10 +1,12 @@
+import { Map as LinkMap } from 'lnmap'
+
 export class MemoryBlockstore {
-  /** @type {Map<string, Uint8Array>} */
-  #blocks = new Map()
+  /** @type {Map<import('multiformats').UnknownLink, Uint8Array>} */
+  #blocks = new LinkMap()
 
   /** @param {import('multiformats').UnknownLink} cid */
   async get (cid) {
-    const bytes = this.#blocks.get(cid.toString())
+    const bytes = this.#blocks.get(cid)
     if (bytes) return { cid, bytes }
   }
 
@@ -13,6 +15,6 @@ export class MemoryBlockstore {
    * @param {Uint8Array} bytes
    */
   async put (cid, bytes) {
-    this.#blocks.set(cid.toString(), bytes)
+    this.#blocks.set(cid, bytes)
   }
 }

--- a/test/testmark.test.js
+++ b/test/testmark.test.js
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import { Readable } from 'node:stream'
 import { CARReaderStream } from 'carstream'
 // @ts-expect-error
-import { unixfs20mVarietyCases, unixfs20mVarietyCar } from '@ipld/specs/trustless-pathing/unixfs_20m_variety.js'
+import { unixfs20mVarietyCases, unixfs20mVarietyCar } from '@ipld/specs/trustless-pathing/unixfs_20m_variety'
 import { MemoryBlockstore } from './helpers/blockstore.js'
 import { Dagula } from '../index.js'
 
@@ -60,18 +60,15 @@ test.before(async t => {
   t.context.dagula = new Dagula(blockstore)
 })
 
-test('unixfs_20m_variety', async t => {
-  /** @type {TestCase[]} */
-  const cases = await unixfs20mVarietyCases()
+/** @type {TestCase[]} */
+const cases = unixfs20mVarietyCases()
 
-  for (const testCase of cases) {
-    const isSkip = skips.some(s => s === testCase.name)
-    if (isSkip) {
-      t.log(`⚠️ SKIPPED: ${testCase.name}`)
-      continue
-    }
+for (const testCase of cases) {
+  const isSkip = skips.some(s => s === testCase.name)
+  const testFn = isSkip ? test.skip : test
 
-    t.log(`${testCase.name}\n${testCase.asQuery()}`)
+  testFn(testCase.name, async t => {
+    t.log(testCase.asQuery())
     const { cidPath, options } = parseQuery(testCase.asQuery())
     const blocks = []
     const iterator = t.context.dagula.getPath(cidPath, options)
@@ -85,5 +82,5 @@ test('unixfs_20m_variety', async t => {
       t.assert(block)
       t.is(block.cid.toString(), cid.toString())
     }
-  }
-})
+  })
+}

--- a/test/testmark.test.js
+++ b/test/testmark.test.js
@@ -70,6 +70,7 @@ test('unixfs_20m_variety', async t => {
       t.log(`⚠️ SKIPPED: ${testCase.name}`)
       continue
     }
+
     t.log(`${testCase.name}\n${testCase.asQuery()}`)
     const { cidPath, options } = parseQuery(testCase.asQuery())
     const blocks = []
@@ -77,6 +78,8 @@ test('unixfs_20m_variety', async t => {
     for await (const block of iterator) {
       blocks.push(block)
     }
+
+    t.is(blocks.length, testCase.expectedCids.length)
     for (const [i, cid] of testCase.expectedCids.entries()) {
       const block = blocks[i]
       t.assert(block)

--- a/test/testmark.test.js
+++ b/test/testmark.test.js
@@ -1,0 +1,69 @@
+import anyTest from 'ava'
+import fs from 'node:fs'
+import { Readable } from 'node:stream'
+import { CARReaderStream } from 'carstream'
+import * as Testmark from 'testmark.js'
+import * as Link from 'multiformats/link'
+import { MemoryBlockstore } from './helpers/blockstore.js'
+import { Dagula } from '../index.js'
+
+const test = /** @type {import('ava').TestFn<{ dagula: import('../index.js').IDagula }>} */ (anyTest)
+const doc = Testmark.parse(fs.readFileSync('./test/fixtures/unixfs_20m_variety.md', 'utf8'))
+
+test.before(async t => {
+  const blockstore = new MemoryBlockstore()
+  const car = /** @type {ReadableStream<Uint8Array>} */
+    (Readable.toWeb(fs.createReadStream('./test/fixtures/unixfs_20m_variety.car')))
+  await car
+    .pipeThrough(new CARReaderStream())
+    .pipeTo(new WritableStream({ write: block => blockstore.put(block.cid, block.bytes) }))
+  t.context.dagula = new Dagula(blockstore)
+})
+
+/**
+ * @param {string} body
+ * @returns {{ cidPath: string, options: import('../index').DagScopeOptions & import('../index').EntityBytesOptions }}
+ */
+const parseQueryBody = body => {
+  const url = new URL(body, 'http://localhost')
+  /** @type {import('../index').DagScopeOptions & import('../index').EntityBytesOptions} */
+  // @ts-expect-error
+  const options = { dagScope: url.searchParams.get('dag-scope') ?? undefined }
+  const entityBytesstr = url.searchParams.get('entity-bytes')
+  if (entityBytesstr) {
+    const [from, to] = entityBytesstr.split(':')
+    options.entityBytes = { from: parseInt(from), to: to === '*' ? to : parseInt(to) }
+  }
+  return { cidPath: url.pathname.replace('/ipfs/', ''), options }
+}
+
+/** @param {string} body */
+const parseExecutionBody = body => body.split('\n').filter(Boolean).map(line => {
+  const parts = line.split(' | ').map(s => s.trimEnd())
+  return { cid: Link.parse(parts[0]), type: parts[1], description: parts[2] }
+})
+
+for (const queryHunk of doc.dataHunks) {
+  if (!queryHunk.name.endsWith('/query')) continue
+
+  test(queryHunk.name.replace('test/', '').replace('/query', ''), async t => {
+    const { cidPath, options } = parseQueryBody(queryHunk.body)
+    const blocks = []
+    const iterator = t.context.dagula.getPath(cidPath, options)
+    for await (const block of iterator) {
+      blocks.push(block)
+    }
+
+    const executionHunkName = queryHunk.name.replace('/query', '/execution')
+    const executionHunk = doc.hunksByName.get(executionHunkName)
+    if (!executionHunk) {
+      throw new Error(`execution hunk not found: ${executionHunkName}`)
+    }
+
+    for (const [i, { cid }] of parseExecutionBody(executionHunk.body).entries()) {
+      const block = blocks[i]
+      t.assert(block)
+      t.is(block.cid.toString(), cid.toString())
+    }
+  })
+}

--- a/test/testmark.test.js
+++ b/test/testmark.test.js
@@ -11,7 +11,7 @@ import { Dagula } from '../index.js'
 
 const test = /** @type {import('ava').TestFn<{ dagula: import('../index.js').IDagula }>} */ (anyTest)
 
-// https://github.com/ipld/ipld/pull/296#issuecomment-1691532242
+// TODO: remove when https://github.com/ipfs/js-ipfs-unixfs/pull/355 lands
 const skips = [
   'sharded_file_in_hamt_in_directory/all',
   'sharded_file_in_hamt_in_directory/entity',


### PR DESCRIPTION
This PR adds an `entityBytes?: { from: number, to: number | '*' }` option to `getPath`.

See `entity-bytes` from https://github.com/ipfs/specs/blob/main/src/http-gateways/trustless-gateway.md#request-query-parameters for details.

Includes and uses [trustless pathing fixtures](https://github.com/ipld/ipld/tree/master/specs/transport/trustless-pathing/fixtures) to test implementation.

refs https://github.com/ipld/ipld/pull/296